### PR TITLE
#7: Fix potential NPE.

### DIFF
--- a/src/main/java/io/fabric8/vertx/maven/plugin/mojos/AbstractVertxMojo.java
+++ b/src/main/java/io/fabric8/vertx/maven/plugin/mojos/AbstractVertxMojo.java
@@ -188,7 +188,7 @@ public abstract class AbstractVertxMojo extends AbstractMojo {
                 return Optional.of(finalNameArtifact.toFile());
             }
         } else {
-            return Optional.of(artifact.getFile());
+            return Optional.ofNullable(artifact.getFile());
         }
         return Optional.empty();
     }


### PR DESCRIPTION
The code:

    Optional.of(artifact.getFile())

as found inside AbstractVertxMojo class, will throw an NPE if the file is null.