### PR TITLE
Webjar and js deps support

### DIFF
--- a/src/it/webjar-it/invoker.properties
+++ b/src/it/webjar-it/invoker.properties
@@ -1,0 +1,2 @@
+#invoker.mavenOpts=-Xdebug -Xnoagent -Xrunjdwp:transport=dt_socket,server=y,suspend=y,address=9001
+#invoker.debug=true

--- a/src/it/webjar-it/pom.xml
+++ b/src/it/webjar-it/pom.xml
@@ -1,0 +1,84 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~   Copyright 2016 Kamesh Sampath
+  ~
+  ~   Licensed under the Apache License, Version 2.0 (the "License");
+  ~   you may not use this file except in compliance with the License.
+  ~   You may obtain a copy of the License at
+  ~
+  ~         http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~   Unless required by applicable law or agreed to in writing, software
+  ~   distributed under the License is distributed on an "AS IS" BASIS,
+  ~   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~   See the License for the specific language governing permissions and
+  ~   limitations under the License.
+  -->
+
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/POM/4.0.0"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>org.workspace7.maven.plugins.vertx.it</groupId>
+    <artifactId>vertx-demo-pkg</artifactId>
+    <version>0.0.1.BUILD-SNAPSHOT</version>
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <vertx.version>3.3.2</vertx.version>
+        <vertx.verticle>org.vertx.demo.MainVerticle</vertx.verticle>
+    </properties>
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <source>1.8</source>
+                    <target>1.8</target>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>@project.groupId@</groupId>
+                <artifactId>@project.artifactId@</artifactId>
+                <version>@project.version@</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>initialize</goal>
+                            <goal>package</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+    <dependencies>
+        <dependency>
+            <groupId>io.vertx</groupId>
+            <artifactId>vertx-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.vertx</groupId>
+            <artifactId>vertx-web</artifactId>
+            <version>3.3.3</version>
+            <classifier>client</classifier>
+            <type>js</type>
+        </dependency>
+        <dependency>
+            <groupId>org.webjars</groupId>
+            <artifactId>jquery</artifactId>
+            <version>3.1.1</version>
+        </dependency>
+    </dependencies>
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>io.vertx</groupId>
+                <artifactId>vertx-dependencies</artifactId>
+                <version>${vertx.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+</project>

--- a/src/it/webjar-it/src/main/java/org/vertx/demo/MainVerticle.java
+++ b/src/it/webjar-it/src/main/java/org/vertx/demo/MainVerticle.java
@@ -1,0 +1,30 @@
+/*
+ *   Copyright 2016 Kamesh Sampath
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package org.vertx.demo;
+
+import io.vertx.core.AbstractVerticle;
+import io.vertx.core.*;
+
+public class MainVerticle extends AbstractVerticle {
+
+	@Override
+	public void start() {
+		vertx.createHttpServer()
+				.requestHandler(req -> req.response().end("Hello World!"))
+				.listen(8080);
+	}
+}

--- a/src/it/webjar-it/verify.groovy
+++ b/src/it/webjar-it/verify.groovy
@@ -1,0 +1,33 @@
+/*
+ *   Copyright 2016 Kamesh Sampath
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+
+import io.fabric8.vertx.maven.plugin.Verify
+
+import java.util.jar.JarFile
+
+String base = basedir
+File primaryArtifactFile = new File(base, "target/vertx-demo-pkg-0.0.1.BUILD-SNAPSHOT.jar")
+
+assert primaryArtifactFile.exists()
+
+File fatJarFile = new File(base, "target/vertx-demo-pkg-0.0.1.BUILD-SNAPSHOT-fat.jar")
+Verify.verifyVertxJar(fatJarFile)
+
+JarFile jar = new JarFile(fatJarFile)
+assert jar.getEntry("webroot") != null
+assert jar.getEntry("webroot/vertx-web-3.3.3-client.js") != null
+assert jar.getEntry("webroot/jquery/jquery.js") != null

--- a/src/it/webjar-no-strip-it/invoker.properties
+++ b/src/it/webjar-no-strip-it/invoker.properties
@@ -1,0 +1,2 @@
+#invoker.mavenOpts=-Xdebug -Xnoagent -Xrunjdwp:transport=dt_socket,server=y,suspend=y,address=9001
+#invoker.debug=true

--- a/src/it/webjar-no-strip-it/pom.xml
+++ b/src/it/webjar-no-strip-it/pom.xml
@@ -1,0 +1,89 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~   Copyright 2016 Kamesh Sampath
+  ~
+  ~   Licensed under the Apache License, Version 2.0 (the "License");
+  ~   you may not use this file except in compliance with the License.
+  ~   You may obtain a copy of the License at
+  ~
+  ~         http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~   Unless required by applicable law or agreed to in writing, software
+  ~   distributed under the License is distributed on an "AS IS" BASIS,
+  ~   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~   See the License for the specific language governing permissions and
+  ~   limitations under the License.
+  -->
+
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/POM/4.0.0"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>org.workspace7.maven.plugins.vertx.it</groupId>
+    <artifactId>vertx-demo-pkg</artifactId>
+    <version>0.0.1.BUILD-SNAPSHOT</version>
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <vertx.version>3.3.2</vertx.version>
+        <vertx.verticle>org.vertx.demo.MainVerticle</vertx.verticle>
+    </properties>
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <source>1.8</source>
+                    <target>1.8</target>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>@project.groupId@</groupId>
+                <artifactId>@project.artifactId@</artifactId>
+                <version>@project.version@</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>initialize</goal>
+                            <goal>package</goal>
+                        </goals>
+                        <configuration>
+                            <webRoot>target/classes/assets</webRoot>
+                            <stripWebJarVersion>false</stripWebJarVersion>
+                            <stripJavaScriptDepdendencyVersion>false</stripJavaScriptDepdendencyVersion>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+    <dependencies>
+        <dependency>
+            <groupId>io.vertx</groupId>
+            <artifactId>vertx-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.vertx</groupId>
+            <artifactId>vertx-web</artifactId>
+            <version>3.3.3</version>
+            <classifier>client</classifier>
+            <type>js</type>
+        </dependency>
+        <dependency>
+            <groupId>org.webjars</groupId>
+            <artifactId>jquery</artifactId>
+            <version>3.1.1</version>
+        </dependency>
+    </dependencies>
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>io.vertx</groupId>
+                <artifactId>vertx-dependencies</artifactId>
+                <version>${vertx.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+</project>

--- a/src/it/webjar-no-strip-it/src/main/java/org/vertx/demo/MainVerticle.java
+++ b/src/it/webjar-no-strip-it/src/main/java/org/vertx/demo/MainVerticle.java
@@ -14,17 +14,17 @@
  *   limitations under the License.
  */
 
+package org.vertx.demo;
 
-import io.fabric8.vertx.maven.plugin.Verify
+import io.vertx.core.AbstractVerticle;
+import io.vertx.core.*;
 
-import java.util.jar.JarFile
+public class MainVerticle extends AbstractVerticle {
 
-String base = basedir
-File primaryArtifactFile = new File(base, "target/vertx-demo-pkg-0.0.1.BUILD-SNAPSHOT.jar")
-assert primaryArtifactFile.exists()
-Verify.verifyVertxJar(primaryArtifactFile)
-
-JarFile jar = new JarFile(primaryArtifactFile)
-assert jar.getEntry("webroot") != null
-assert jar.getEntry("webroot/vertx-web-client.js") != null
-assert jar.getEntry("webroot/jquery/jquery.js") != null
+	@Override
+	public void start() {
+		vertx.createHttpServer()
+				.requestHandler(req -> req.response().end("Hello World!"))
+				.listen(8080);
+	}
+}

--- a/src/it/webjar-no-strip-it/verify.groovy
+++ b/src/it/webjar-no-strip-it/verify.groovy
@@ -25,6 +25,6 @@ assert primaryArtifactFile.exists()
 Verify.verifyVertxJar(primaryArtifactFile)
 
 JarFile jar = new JarFile(primaryArtifactFile)
-assert jar.getEntry("webroot") != null
-assert jar.getEntry("webroot/vertx-web-client.js") != null
-assert jar.getEntry("webroot/jquery/jquery.js") != null
+assert jar.getEntry("assets") != null
+assert jar.getEntry("assets/vertx-web-3.3.3-client.js") != null
+assert jar.getEntry("assets/jquery/3.1.1/jquery.js") != null

--- a/src/main/java/io/fabric8/vertx/maven/plugin/mojos/AbstractVertxMojo.java
+++ b/src/main/java/io/fabric8/vertx/maven/plugin/mojos/AbstractVertxMojo.java
@@ -16,6 +16,7 @@
 
 package io.fabric8.vertx.maven.plugin.mojos;
 
+import io.fabric8.vertx.maven.plugin.utils.WebJars;
 import org.apache.maven.artifact.Artifact;
 import org.apache.maven.execution.MavenSession;
 import org.apache.maven.plugin.AbstractMojo;
@@ -210,11 +211,18 @@ public abstract class AbstractVertxMojo extends AbstractMojo {
      */
     protected Set<Optional<File>> extractArtifactPaths(Set<Artifact> artifacts) {
         return artifacts
-                .stream()
-                .filter(e -> e.getScope().equals("compile") || e.getScope().equals("runtime"))
-                .map(this::asMavenCoordinates)
-                .map(this::resolveArtifact)
-                .collect(Collectors.toSet());
+            .stream()
+            .filter(e -> e.getScope().equals("compile") || e.getScope().equals("runtime"))
+            .filter(e -> e.getType().equalsIgnoreCase("jar"))
+            .filter(e -> !WebJars.isWebJar(getLog(), e.getFile()))
+            .map(this::asMavenCoordinates)
+            .distinct()
+            .map(s -> {
+                System.out.println(">>> " + s);
+                return s;
+            })
+            .map(this::resolveArtifact)
+            .collect(Collectors.toSet());
     }
 
     /**
@@ -230,11 +238,11 @@ public abstract class AbstractVertxMojo extends AbstractMojo {
         // although I don't think it will change any time soon since probably many people already
         // rely on it)
         StringBuilder artifactCords = new StringBuilder().
-                append(artifact.getGroupId())
-                .append(":")
-                .append(artifact.getArtifactId())
-                .append(":")
-                .append(artifact.getVersion());
+            append(artifact.getGroupId())
+            .append(":")
+            .append(artifact.getArtifactId())
+            .append(":")
+            .append(artifact.getVersion());
         if (!"jar".equals(artifact.getType())) {
             artifactCords.append(":").append(artifact.getType());
         }

--- a/src/main/java/io/fabric8/vertx/maven/plugin/mojos/AbstractVertxMojo.java
+++ b/src/main/java/io/fabric8/vertx/maven/plugin/mojos/AbstractVertxMojo.java
@@ -204,7 +204,8 @@ public abstract class AbstractVertxMojo extends AbstractMojo {
     }
 
     /**
-     * this method helps in extracting the Artifact paths from the Maven local repository
+     * this method helps in extracting the Artifact paths from the Maven local repository.
+     * If does does not handle WebJars and non-jar dependencies.
      *
      * @param artifacts - the collection of artifacts which needs to be resolved to local {@link File}
      * @return A {@link Set} of {@link Optional} file paths
@@ -217,10 +218,6 @@ public abstract class AbstractVertxMojo extends AbstractMojo {
             .filter(e -> !WebJars.isWebJar(getLog(), e.getFile()))
             .map(this::asMavenCoordinates)
             .distinct()
-            .map(s -> {
-                System.out.println(">>> " + s);
-                return s;
-            })
             .map(this::resolveArtifact)
             .collect(Collectors.toSet());
     }

--- a/src/main/java/io/fabric8/vertx/maven/plugin/mojos/InitializeMojo.java
+++ b/src/main/java/io/fabric8/vertx/maven/plugin/mojos/InitializeMojo.java
@@ -38,6 +38,9 @@ public class InitializeMojo extends AbstractVertxMojo {
     @Parameter(defaultValue = "true")
     private boolean stripWebJarVersion;
 
+    @Parameter(defaultValue = "true")
+    private boolean stripJavaScriptDepdendencyVersion;
+
     @Override
     public void execute() throws MojoExecutionException, MojoFailureException {
         // Initialize the web root directory with Vert.x web default.
@@ -95,7 +98,17 @@ public class InitializeMojo extends AbstractVertxMojo {
                 Optional<File> file = getArtifactFile(artifact);
                 if (file.isPresent()) {
                     try {
-                        FileUtils.copyFileToDirectory(file.get(), createWebRootDirIfNeeded());
+                        if (stripJavaScriptDepdendencyVersion) {
+                            String name = artifact.getArtifactId();
+                            if (artifact.getClassifier() != null) {
+                                name += "-" + artifact.getClassifier();
+                            }
+                            name += ".js";
+                            File output = new File(createWebRootDirIfNeeded(), name);
+                            FileUtils.copyFile(file.get(), output);
+                        } else {
+                            FileUtils.copyFileToDirectory(file.get(), createWebRootDirIfNeeded());
+                        }
                     } catch (IOException e) {
                         throw new MojoExecutionException("Unable to copy '"
                             + artifact.toString() + "'", e);

--- a/src/main/java/io/fabric8/vertx/maven/plugin/mojos/InitializeMojo.java
+++ b/src/main/java/io/fabric8/vertx/maven/plugin/mojos/InitializeMojo.java
@@ -1,5 +1,8 @@
 package io.fabric8.vertx.maven.plugin.mojos;
 
+import io.fabric8.vertx.maven.plugin.utils.WebJars;
+import org.apache.commons.io.FileUtils;
+import org.apache.maven.artifact.Artifact;
 import org.apache.maven.execution.ExecutionListener;
 import org.apache.maven.execution.MavenExecutionRequest;
 import org.apache.maven.execution.MavenSession;
@@ -11,6 +14,12 @@ import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
 import org.apache.maven.plugins.annotations.ResolutionScope;
 
+import java.io.File;
+import java.io.IOException;
+import java.util.LinkedHashSet;
+import java.util.Optional;
+import java.util.Set;
+
 /**
  * @author <a href="http://escoffier.me">Clement Escoffier</a>
  */
@@ -18,16 +27,84 @@ import org.apache.maven.plugins.annotations.ResolutionScope;
     defaultPhase = LifecyclePhase.INITIALIZE,
     requiresDependencyCollection = ResolutionScope.COMPILE_PLUS_RUNTIME,
     requiresDependencyResolution = ResolutionScope.COMPILE_PLUS_RUNTIME)
-public class InitializeMojo extends AbstractMojo {
+public class InitializeMojo extends AbstractVertxMojo {
 
     @Parameter(defaultValue = "${session}", readonly = true)
     private MavenSession session;
 
+    @Parameter
+    private File webRoot;
+
+    @Parameter(defaultValue = "true")
+    private boolean stripWebJarVersion;
 
     @Override
     public void execute() throws MojoExecutionException, MojoFailureException {
+        // Initialize the web root directory with Vert.x web default.
+        // The directory is only created on demand.
+        if (webRoot == null) {
+            webRoot = new File(project.getBuild().getOutputDirectory(), "webroot");
+        }
+
+        Set<Artifact> dependencies = new LinkedHashSet<>();
+        dependencies.addAll(this.project.getDependencyArtifacts());
+        dependencies.addAll(this.project.getArtifacts());
+
+        copyJSDependencies(dependencies);
+        unpackWebjars(dependencies);
+
+        // Start the spy
         MavenExecutionRequest request = session.getRequest();
         ExecutionListener listener = request.getExecutionListener();
         request.setExecutionListener(new MojoSpy(listener, getLog()));
+    }
+
+    private void unpackWebjars(Set<Artifact> dependencies) throws MojoExecutionException {
+        for (Artifact artifact : dependencies) {
+            Optional<File> maybeFile = getArtifactFile(artifact);
+            if (artifact.getType().equalsIgnoreCase("jar")  && maybeFile.isPresent()) {
+                if (WebJars.isWebJar(getLog(), maybeFile.get())) {
+                    try {
+                        WebJars.extract(this, maybeFile.get(),
+                            createWebRootDirIfNeeded(), stripWebJarVersion);
+                    } catch (IOException e) {
+                        throw new MojoExecutionException("Unable to unpack '"
+                            + artifact.toString() + "'", e);
+                    }
+                }
+            }
+        }
+    }
+
+    private File createWebRootDirIfNeeded() {
+        if (! webRoot.isDirectory()) {
+            boolean created = webRoot.mkdirs();
+            if (created) {
+                getLog().debug("Webroot directory created: " + webRoot.getAbsolutePath());
+            } else {
+                getLog().error("Unable to create directory: " + webRoot.getAbsolutePath());
+            }
+        }
+
+        return webRoot;
+    }
+
+    private void copyJSDependencies(Set<Artifact> dependencies) throws MojoExecutionException {
+        for (Artifact artifact : dependencies) {
+            if (artifact.getType().equalsIgnoreCase("js")) {
+                Optional<File> file = getArtifactFile(artifact);
+                if (file.isPresent()) {
+                    try {
+                        FileUtils.copyFileToDirectory(file.get(), createWebRootDirIfNeeded());
+                    } catch (IOException e) {
+                        throw new MojoExecutionException("Unable to copy '"
+                            + artifact.toString() + "'", e);
+                    }
+                } else {
+                    getLog().warn("Skipped the copy of '"
+                        + artifact.toString() + "' - The artifact file does not exist");
+                }
+            }
+        }
     }
 }

--- a/src/main/java/io/fabric8/vertx/maven/plugin/mojos/InitializeMojo.java
+++ b/src/main/java/io/fabric8/vertx/maven/plugin/mojos/InitializeMojo.java
@@ -27,7 +27,6 @@ public class InitializeMojo extends AbstractMojo {
     @Override
     public void execute() throws MojoExecutionException, MojoFailureException {
         MavenExecutionRequest request = session.getRequest();
-        getLog().info("Request : " + request);
         ExecutionListener listener = request.getExecutionListener();
         request.setExecutionListener(new MojoSpy(listener, getLog()));
     }

--- a/src/main/java/io/fabric8/vertx/maven/plugin/utils/WebJars.java
+++ b/src/main/java/io/fabric8/vertx/maven/plugin/utils/WebJars.java
@@ -1,0 +1,132 @@
+package io.fabric8.vertx.maven.plugin.utils;
+
+import io.fabric8.vertx.maven.plugin.mojos.AbstractVertxMojo;
+import org.apache.commons.io.IOUtils;
+import org.apache.maven.plugin.logging.Log;
+
+import java.io.Closeable;
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Enumeration;
+import java.util.LinkedHashSet;
+import java.util.Set;
+import java.util.jar.JarEntry;
+import java.util.jar.JarFile;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipFile;
+
+/**
+ * @author <a href="http://escoffier.me">Clement Escoffier</a>
+ */
+public class WebJars {
+
+    /**
+     * A regex extracting the library name and version from Zip Entry names.
+     */
+    public static final Pattern WEBJAR_REGEX = Pattern.compile(".*META-INF/resources/webjars/([^/]+)/([^/]+)/.*");
+    /**
+     * The directory within jar file where webjar resources are located.
+     */
+    public static final String WEBJAR_LOCATION = "META-INF/resources/webjars/";
+
+    /**
+     * A regex to extract the different part of the path of a file from a library included in a webjar.
+     */
+    public static final Pattern WEBJAR_INTERNAL_PATH_REGEX = Pattern.compile("([^/]+)/([^/]+)/(.*)");
+
+
+    /**
+     * Checks whether the given file is a WebJar or not (http://www.webjars.org/documentation).
+     * The check is based on the presence of {@literal META-INF/resources/webjars/} directory in the jar file.
+     *
+     * @param file the file.
+     * @return {@literal true} if it's a bundle, {@literal false} otherwise.
+     */
+    public static boolean isWebJar(Log log, File file) {
+        if (file == null) {
+            return false;
+        }
+        Set<String> found = new LinkedHashSet<>();
+        if (file.isFile() && file.getName().endsWith(".jar")) {
+            JarFile jar = null;
+            try {
+                jar = new JarFile(file);
+
+                // Fast return if the base structure is not there
+                if (jar.getEntry(WEBJAR_LOCATION) == null) {
+                    return false;
+                }
+
+                Enumeration<JarEntry> entries = jar.entries();
+                while (entries.hasMoreElements()) {
+                    JarEntry entry = entries.nextElement();
+                    Matcher matcher = WEBJAR_REGEX.matcher(entry.getName());
+                    if (matcher.matches()) {
+                        found.add(matcher.group(1) + "-" + matcher.group(2));
+                    }
+                }
+            } catch (IOException e) {
+                log.error("Cannot check if the file " + file.getName()
+                    + " is a webjar, cannot open it", e);
+                return false;
+            } finally {
+                final JarFile finalJar = jar;
+                IOUtils.closeQuietly(() -> {
+                    if (finalJar != null) {
+                        finalJar.close();
+                    }
+                });
+            }
+
+            for (String lib : found) {
+                log.info("Web Library found in " + file.getName() + " : " + lib);
+            }
+
+            return !found.isEmpty();
+        }
+
+        return false;
+    }
+
+    public static void extract(final AbstractVertxMojo mojo, File in, File out, boolean stripVersion) throws IOException {
+        ZipFile file = new ZipFile(in);
+        try {
+            Enumeration<? extends ZipEntry> entries = file.entries();
+            while (entries.hasMoreElements()) {
+                ZipEntry entry = entries.nextElement();
+                if (entry.getName().startsWith(WEBJAR_LOCATION) && !entry.isDirectory()) {
+                    // Compute destination.
+                    File output = new File(out,
+                        entry.getName().substring(WEBJAR_LOCATION.length()));
+                    if (stripVersion) {
+                        String path = entry.getName().substring(WEBJAR_LOCATION.length());
+                        Matcher matcher = WEBJAR_INTERNAL_PATH_REGEX.matcher(path);
+                        if (matcher.matches()) {
+                            output = new File(out, matcher.group(1) + "/" + matcher.group(3));
+                        } else {
+                            mojo.getLog().warn(path + " does not match the regex - did not strip the version for this" +
+                                " file");
+                        }
+                    }
+                    InputStream stream = null;
+                    try {
+                        stream = file.getInputStream(entry);
+                        output.getParentFile().mkdirs();
+                        org.apache.commons.io.FileUtils.copyInputStreamToFile(stream, output);
+                    } catch (IOException e) {
+                        mojo.getLog().error("Cannot unpack " + entry.getName() + " from "
+                            + file.getName(), e);
+                        throw e;
+                    } finally {
+                        IOUtils.closeQuietly(stream);
+                    }
+                }
+            }
+        } finally {
+            IOUtils.closeQuietly(file);
+        }
+    }
+}


### PR DESCRIPTION
This PR add supports for webjar and js dependencies.

* Dependencies that are webjars are extracted to the _webRoot_ directory. Versions can be stripped (enabled by default)
* JS dependencies are also copied to the _webRoot_ directory. Versions can be stripped (enabled by default)

The copy and extraction are made during the Initialize phase and so are not replayed during the redeploy (as it would change the pom.xml file)

The default _webRoot_ is `target/classes/webroot` as it's the Vert.x Web default.