### PR TITLE
Avoid writing effective pom

### DIFF
--- a/src/main/java/io/fabric8/vertx/maven/plugin/mojos/SetupMojo.java
+++ b/src/main/java/io/fabric8/vertx/maven/plugin/mojos/SetupMojo.java
@@ -56,7 +56,8 @@ public class SetupMojo extends AbstractMojo {
     @Override
     public void execute() throws MojoExecutionException, MojoFailureException {
 
-        Model model = project.getModel();
+        //We should get cloned of the OriginalModel, as project.getModel will return effective model
+        Model model = project.getOriginalModel().clone();
         File pomFile = project.getFile();
 
         Optional<Plugin> vmPlugin = mojoUtils.hasPlugin(project, "io.fabric8:vertx-maven-plugin");


### PR DESCRIPTION
Fixes the setup goal writing back project's effective pom post execution of vertx:setup