### PR TITLE
Simplify the process when we don’t have a jar as input

### DIFF
--- a/src/it/package-no-jar-it/invoker.properties
+++ b/src/it/package-no-jar-it/invoker.properties
@@ -1,0 +1,18 @@
+#
+#
+#   Copyright (c) 2016 Red Hat, Inc.
+#
+#   Red Hat licenses this file to you under the Apache License, version
+#   2.0 (the "License"); you may not use this file except in compliance
+#   with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+#   implied.  See the License for the specific language governing
+#   permissions and limitations under the License.
+#
+# invoker.mavenOpts=-Xdebug -Xnoagent -Xrunjdwp:transport=dt_socket,server=y,suspend=y,address=9001
+invoker.debug=false

--- a/src/it/package-no-jar-it/pom.xml
+++ b/src/it/package-no-jar-it/pom.xml
@@ -1,0 +1,88 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~
+  ~   Copyright (c) 2016 Red Hat, Inc.
+  ~
+  ~   Red Hat licenses this file to you under the Apache License, version
+  ~   2.0 (the "License"); you may not use this file except in compliance
+  ~   with the License.  You may obtain a copy of the License at
+  ~
+  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~   Unless required by applicable law or agreed to in writing, software
+  ~   distributed under the License is distributed on an "AS IS" BASIS,
+  ~   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+  ~   implied.  See the License for the specific language governing
+  ~   permissions and limitations under the License.
+  -->
+
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/POM/4.0.0"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>org.workspace7.maven.plugins.vertx.it</groupId>
+    <artifactId>vertx-demo-pkg</artifactId>
+    <version>0.0.1.BUILD-SNAPSHOT</version>
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <vertx.version>3.3.3</vertx.version>
+        <vertx.verticle>org.vertx.demo.MainVerticle</vertx.verticle>
+    </properties>
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <source>1.8</source>
+                    <target>1.8</target>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>@project.groupId@</groupId>
+                <artifactId>@project.artifactId@</artifactId>
+                <version>@project.version@</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>initialize</goal>
+                            <goal>package</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <configuration>
+                    <classifier>foo</classifier>
+                </configuration>
+            </plugin>
+
+            <plugin>
+                <artifactId>maven-jar-plugin</artifactId>
+                <version>3.0.2</version>
+                <executions>
+                    <execution>
+                        <!-- skip the jar -->
+                        <id>default-jar</id>
+                        <phase>never</phase>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+    <dependencies>
+        <dependency>
+            <groupId>io.vertx</groupId>
+            <artifactId>vertx-core</artifactId>
+        </dependency>
+    </dependencies>
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>io.vertx</groupId>
+                <artifactId>vertx-dependencies</artifactId>
+                <version>${vertx.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+</project>

--- a/src/it/package-no-jar-it/src/main/java/org/vertx/demo/MainVerticle.java
+++ b/src/it/package-no-jar-it/src/main/java/org/vertx/demo/MainVerticle.java
@@ -1,0 +1,31 @@
+/*
+ *
+ *   Copyright (c) 2016 Red Hat, Inc.
+ *
+ *   Red Hat licenses this file to you under the Apache License, version
+ *   2.0 (the "License"); you may not use this file except in compliance
+ *   with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ *   implied.  See the License for the specific language governing
+ *   permissions and limitations under the License.
+ */
+
+package org.vertx.demo;
+
+import io.vertx.core.AbstractVerticle;
+import io.vertx.core.*;
+
+public class MainVerticle extends AbstractVerticle {
+
+	@Override
+	public void start() {
+		vertx.createHttpServer()
+				.requestHandler(req -> req.response().end("Hello World!"))
+				.listen(8080);
+	}
+}

--- a/src/it/package-no-jar-it/verify.groovy
+++ b/src/it/package-no-jar-it/verify.groovy
@@ -1,0 +1,29 @@
+import io.fabric8.vertx.maven.plugin.Verify
+
+/*
+ *
+ *   Copyright (c) 2016 Red Hat, Inc.
+ *
+ *   Red Hat licenses this file to you under the Apache License, version
+ *   2.0 (the "License"); you may not use this file except in compliance
+ *   with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ *   implied.  See the License for the specific language governing
+ *   permissions and limitations under the License.
+ */
+
+String base = basedir
+File primaryArtifactFile = new File(base, "target/vertx-demo-pkg-0.0.1.BUILD-SNAPSHOT-foo.jar")
+File not_created = new File(base, "target/vertx-demo-pkg-0.0.1.BUILD-SNAPSHOT.jar")
+
+assert primaryArtifactFile.isFile()
+assert  ! not_created.isFile()
+
+Verify.verifyVertxJar(primaryArtifactFile)
+
+

--- a/src/main/java/io/fabric8/vertx/maven/plugin/mojos/AbstractRunMojo.java
+++ b/src/main/java/io/fabric8/vertx/maven/plugin/mojos/AbstractRunMojo.java
@@ -449,7 +449,7 @@ public class AbstractRunMojo extends AbstractVertxMojo {
         @Override
         public Void call() {
 
-            final MojoUtils mojoUtils = new MojoUtils().withLog(getLog());
+            final MojoUtils mojoUtils = new MojoUtils();
 
             try {
                 mojoUtils.compile(project, mavenSession, buildPluginManager);
@@ -468,7 +468,7 @@ public class AbstractRunMojo extends AbstractVertxMojo {
         @Override
         public Void call() {
 
-            final MojoUtils mojoUtils = new MojoUtils().withLog(getLog());
+            final MojoUtils mojoUtils = new MojoUtils();
 
             try {
                 mojoUtils.copyResources(project, mavenSession, buildPluginManager);

--- a/src/main/java/io/fabric8/vertx/maven/plugin/mojos/PackageMojo.java
+++ b/src/main/java/io/fabric8/vertx/maven/plugin/mojos/PackageMojo.java
@@ -94,11 +94,6 @@ public class PackageMojo extends AbstractVertxMojo {
 
         Optional<File> primaryArtifactFile = getArtifactFile(artifact);
 
-        if (!primaryArtifactFile.isPresent() || !primaryArtifactFile.get().exists()) {
-            // TODO this need to be tested
-            mojoUtils.withLog(getLog()).buildPrimaryArtifact(this.project, this.mavenSession, this.buildPluginManager);
-        }
-
         //Step 0: Resolve and Collect Dependencies as g:a:v:t:c coordinates
 
         Set<Optional<File>> compileAndRuntimeDeps = extractArtifactPaths(this.project.getDependencyArtifacts());
@@ -115,18 +110,20 @@ public class PackageMojo extends AbstractVertxMojo {
 
             Path pathProjectBuildDir = Paths.get(this.projectBuildDir);
 
-            //TODO Handle the case where the primary article is NOT there.
+            File primaryFile = null;
+            if (primaryArtifactFile.isPresent()) {
+                primaryFile = primaryArtifactFile.get();
+            }
 
             File fatJarFile = packageHelper
                     .log(getLog())
-                    .build(pathProjectBuildDir, primaryArtifactFile.get());
+                    .build(pathProjectBuildDir, primaryFile);
 
 
             //  Perform the relocation of the service providers when serviceProviderCombination is defined
             if (serviceProviderCombination == null  || serviceProviderCombination != CombinationStrategy.none) {
                 packageHelper.combineServiceProviders(project,
-                    primaryArtifactFile.get(),
-                        pathProjectBuildDir, fatJarFile);
+                    pathProjectBuildDir, fatJarFile);
             }
 
             ArtifactHandler handler = new DefaultArtifactHandler("jar");

--- a/src/main/java/io/fabric8/vertx/maven/plugin/utils/MojoUtils.java
+++ b/src/main/java/io/fabric8/vertx/maven/plugin/utils/MojoUtils.java
@@ -44,15 +44,9 @@ public class MojoUtils {
 
     /*===  Plugin Keys ====*/
 
-    private static final String JAR_PLUGIN_KEY = "org.apache.maven.plugins:maven-jar-plugin";
     private static final String RESOURCES_PLUGIN_KEY = "org.apache.maven.plugins:maven-resources-plugin";
-    private static final String VERTX_PACKAGE_PLUGIN_KEY = "io.fabric8:vertx-maven-plugin";
 
     /*===  Plugins ====*/
-
-    private static final String G_MAVEN_JAR_PLUGIN = "org.apache.maven.plugins";
-    private static final String A_MAVEN_JAR_PLUGIN = "maven-jar-plugin";
-    private static final String V_MAVEN_JAR_PLUGIN = "maven-jar-plugin-version";
 
     private static final String G_MAVEN_RESOURCES_PLUGIN = "org.apache.maven.plugins";
     private static final String A_MAVEN_RESOURCES_PLUGIN = "maven-resources-plugin";
@@ -64,23 +58,12 @@ public class MojoUtils {
 
     /*===  Goals ====*/
     private static final String GOAL_COMPILE = "compile";
-    private static final String GOAL_PACKAGE = "package";
     private static final String GOAL_RESOURCES = "resources";
 
     private final Properties properties = new Properties();
-    private Log logger;
 
     public MojoUtils() {
-        logger = new SystemStreamLog();
         loadProperties();
-    }
-
-    public MojoUtils withLog(Log log) {
-        if (properties == null || properties.isEmpty()) {
-            loadProperties();
-        }
-        this.logger = log;
-        return this;
     }
 
     /**
@@ -125,50 +108,6 @@ public class MojoUtils {
 
     /**
      * @param project
-     * @param mavenSession
-     * @param buildPluginManager
-     * @throws MojoExecutionException
-     */
-    public void buildPrimaryArtifact(MavenProject project, MavenSession mavenSession,
-                                     BuildPluginManager buildPluginManager) throws MojoExecutionException {
-
-        if (logger != null && logger.isDebugEnabled()) {
-            logger.debug("Primary artifact does not exist, building ...");
-        }
-
-        String packaging = project.getPackaging();
-
-        if ("jar".equals(packaging)) {
-
-            Optional<Plugin> jarPlugin = hasPlugin(project, JAR_PLUGIN_KEY);
-
-            if (jarPlugin.isPresent()) {
-                executeMojo(
-                    jarPlugin.get(),
-                    goal("jar"),
-                    configuration(element("outputDirectory", "${project.build.outputDir}"),
-                        element("classesDirectory", "${project.build.outputDirectory}")),
-                    executionEnvironment(project, mavenSession, buildPluginManager)
-                );
-            } else {
-                executeMojo(
-                    plugin(G_MAVEN_JAR_PLUGIN, A_MAVEN_JAR_PLUGIN,
-                        properties.getProperty(V_MAVEN_JAR_PLUGIN)),
-                    goal("jar"),
-                    configuration(element("outputDirectory", "${project.build.outputDir}"),
-                        element("classesDirectory", "${project.build.outputDirectory}")),
-                    executionEnvironment(project, mavenSession, buildPluginManager)
-                );
-            }
-
-
-        } else {
-            throw new MojoExecutionException("The packaging :" + packaging + " is not supported as of now");
-        }
-    }
-
-    /**
-     * @param project
      * @param pluginKey
      * @return
      */
@@ -200,24 +139,6 @@ public class MojoUtils {
                 && artifactId.equals(d.getArtifactId())).findFirst();
 
         return dep.isPresent();
-    }
-
-    public void buildVertxArtifact(MavenProject project, MavenSession mavenSession,
-                                   BuildPluginManager buildPluginManager) throws MojoExecutionException {
-
-        Plugin vertxMavenPlugin = project.getPlugin(VERTX_PACKAGE_PLUGIN_KEY);
-
-        if (vertxMavenPlugin == null) {
-            throw new MojoExecutionException("Plugin :" + VERTX_PACKAGE_PLUGIN_KEY
-                + " not found or configured");
-        }
-
-        executeMojo(
-            vertxMavenPlugin,
-            goal(GOAL_PACKAGE),
-            configuration(),
-            executionEnvironment(project, mavenSession, buildPluginManager)
-        );
     }
 
     /**


### PR DESCRIPTION
Simplify the process when we don't have a primary artifact already built

Now use target/classes as base. We won’t try to call jar:jar anymore. We report an error if we don’t have neither input jar nor target/classes.