### PR TITLE
Run `compile` if classes are not compiles

### DIFF
--- a/src/main/asciidoc/inc/_vertx-run.adoc
+++ b/src/main/asciidoc/inc/_vertx-run.adoc
@@ -27,7 +27,7 @@ defines all the applicable configurations for the goal
 
 
 | redeployTerminationPeriod
-| the amount of time (in millisecods) to wait after having stopped the application (before launching user command).
+| the amount of time (in milliseconds) to wait after having stopped the application (before launching user command).
   This is useful on Windows, where the process is not killed immediately.
 | vertx.redeploy.termination.period
 | 0

--- a/src/main/asciidoc/inc/_vertx-run.adoc
+++ b/src/main/asciidoc/inc/_vertx-run.adoc
@@ -49,6 +49,15 @@ typically passed to vert.x applications using --java-opts.
 When the redeployment is enabled, it replays the plugin configured between the _generate-source_ and
 _process-classes_ phases.
 
+So to start a Vert.x application just launch:
+
+[source]
+----
+mvn vertx:run
+----
+
+If the sources are not compiled, the plugin executes `mvn compile` for you.
+
 **IMPORTANT**: `vertx:run` starts the application in a forked JVM.
 
 [[vertx:debug]]

--- a/src/main/asciidoc/inc/_vertx-run.adoc
+++ b/src/main/asciidoc/inc/_vertx-run.adoc
@@ -18,7 +18,7 @@ defines all the applicable configurations for the goal
 | redeployScanPeriod
 | The file system check period (in milliseconds)
 | vertx.redeploy.scan.period
-| 250
+| 1000
 
 | redeployGracePeriod
 | The amount of time (in milliseconds) to wait between 2 re-deployments

--- a/src/main/java/io/fabric8/vertx/maven/plugin/mojos/AbstractRunMojo.java
+++ b/src/main/java/io/fabric8/vertx/maven/plugin/mojos/AbstractRunMojo.java
@@ -395,6 +395,10 @@ public class AbstractRunMojo extends AbstractVertxMojo {
 
         return () -> {
             try {
+                //--- vertx-maven-plugin:1.0-SNAPSHOT:run (default-cli) @ vertx-demo
+                getLog().info(">>> "
+                    + execution.getArtifactId() + ":" + execution.getVersion() + ":" + execution.getGoal()
+                    + " (" +execution.getExecutionId() + ") @" + project.getArtifactId());
                 executor.execute();
             } catch (Exception e) {
                 getLog().error("Error while doing incremental build", e);

--- a/src/main/java/io/fabric8/vertx/maven/plugin/mojos/AbstractRunMojo.java
+++ b/src/main/java/io/fabric8/vertx/maven/plugin/mojos/AbstractRunMojo.java
@@ -63,7 +63,7 @@ public class AbstractRunMojo extends AbstractVertxMojo {
     /**
      *
      */
-    @Parameter(alias = "redeployScanPeriod", property = "vertx.redeploy.scan.period")
+    @Parameter(alias = "redeployScanPeriod", property = "vertx.redeploy.scan.period", defaultValue = "1000")
     long redeployScanPeriod;
 
     /**
@@ -290,7 +290,7 @@ public class AbstractRunMojo extends AbstractVertxMojo {
             argsList.add(VERTX_ARG_REDEPLOY_GRACE_PERIOD + redeployGracePeriod);
         }
         if(redeployTerminationPeriod >= 0) {
-            argsList.add(VERTX_ARG_REDEPLOY_TERMINIATION_PERIOD + redeployTerminationPeriod);
+            argsList.add(VERTX_ARG_REDEPLOY_TERMINATION_PERIOD + redeployTerminationPeriod);
         }
     }
 
@@ -386,7 +386,6 @@ public class AbstractRunMojo extends AbstractVertxMojo {
                 .filter(exec -> MojoSpy.PHASES.contains(exec.getLifecyclePhase()))
                 .map(this::toTask)
                 .collect(Collectors.toList());
-
         }
         return list;
     }

--- a/src/main/java/io/fabric8/vertx/maven/plugin/mojos/AbstractRunMojo.java
+++ b/src/main/java/io/fabric8/vertx/maven/plugin/mojos/AbstractRunMojo.java
@@ -127,6 +127,8 @@ public class AbstractRunMojo extends AbstractVertxMojo {
             return;
         }
 
+        compileIfNeeded();
+
         List<String> argsList = new ArrayList<>();
 
         scanAndLoadConfigs();
@@ -160,6 +162,13 @@ public class AbstractRunMojo extends AbstractVertxMojo {
         }
 
         run(argsList);
+    }
+
+    private void compileIfNeeded() {
+        File classes = new File(project.getBuild().getOutputDirectory());
+        if (! classes.isDirectory()) {
+            MavenExecutionUtils.execute("compile", project, mavenSession, lifecycleExecutor, container);
+        }
     }
 
     /**

--- a/src/main/java/io/fabric8/vertx/maven/plugin/mojos/AbstractVertxMojo.java
+++ b/src/main/java/io/fabric8/vertx/maven/plugin/mojos/AbstractVertxMojo.java
@@ -99,7 +99,7 @@ public abstract class AbstractVertxMojo extends AbstractMojo implements Contextu
     /**
      * vert.x redeploy termination period
      */
-    protected static final String VERTX_ARG_REDEPLOY_TERMINIATION_PERIOD = "redeploy-termination-period=";
+    protected static final String VERTX_ARG_REDEPLOY_TERMINATION_PERIOD = "redeploy-termination-period=";
 
     /**
      *

--- a/src/main/java/io/fabric8/vertx/maven/plugin/mojos/MojoSpy.java
+++ b/src/main/java/io/fabric8/vertx/maven/plugin/mojos/MojoSpy.java
@@ -122,10 +122,23 @@ public class MojoSpy extends AbstractExecutionListener {
     public void mojoSucceeded(ExecutionEvent executionEvent) {
         // Unlike mojoStarted, this callback has the lifecycle phase set.
         MojoExecution execution = executionEvent.getMojoExecution();
-        MOJOS.add(execution);
+        addExecutionIfNotContainedAlready(execution);
         if (delegate != null) {
             delegate.mojoSucceeded(executionEvent);
         }
+    }
+
+    private void addExecutionIfNotContainedAlready(MojoExecution execution) {
+        String artifact = execution.getArtifactId();
+        String id = execution.getExecutionId();
+        // We must avoid duplicates in the list
+        for (MojoExecution exec : MOJOS) {
+            if (exec.getArtifactId().equals(artifact)  && exec.getExecutionId().equals(id)) {
+                // Duplicate found.
+                return;
+            }
+        }
+        MOJOS.add(execution);
     }
 
     @Override

--- a/src/test/java/io/fabric8/vertx/maven/plugin/it/RedeployIT.java
+++ b/src/test/java/io/fabric8/vertx/maven/plugin/it/RedeployIT.java
@@ -15,6 +15,7 @@ import java.util.List;
 import java.util.Stack;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
+import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import static com.jayway.awaitility.Awaitility.await;
@@ -172,8 +173,6 @@ public class RedeployIT extends VertxMojoTestBase {
 
         run(verifier);
 
-        Stack<Long> scanTimes = new Stack<>();
-        scanTimes.add(System.currentTimeMillis());
         String response = getHttpResponse();
         assertThat(response).startsWith("Hello");
 
@@ -204,8 +203,8 @@ public class RedeployIT extends VertxMojoTestBase {
         assertThat(lines.isEmpty()).isFalse();
         long redeployCount = lines.stream()
             .filter(s -> pattern.matcher(s).matches())
-            .map(s -> pattern.matcher(s))
-            .filter(m -> m.find())
+            .map(pattern::matcher)
+            .filter(Matcher::find)
             .count();
         assertThat(redeployCount).isEqualTo(2);
     }

--- a/src/test/java/io/fabric8/vertx/maven/plugin/it/RunIT.java
+++ b/src/test/java/io/fabric8/vertx/maven/plugin/it/RunIT.java
@@ -1,0 +1,69 @@
+package io.fabric8.vertx.maven.plugin.it;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import io.fabric8.vertx.maven.plugin.it.invoker.RunningVerifier;
+import org.apache.commons.io.IOUtils;
+import org.apache.maven.it.VerificationException;
+import org.apache.maven.it.Verifier;
+import org.junit.After;
+import org.junit.Test;
+
+import java.io.File;
+import java.io.FileReader;
+import java.util.List;
+import java.util.Stack;
+import java.util.UUID;
+import java.util.concurrent.TimeUnit;
+import java.util.regex.Pattern;
+
+import static com.jayway.awaitility.Awaitility.await;
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Test checking that the redeployment is triggered correctly both in Maven and in Vert.x.
+ */
+public class RunIT extends VertxMojoTestBase {
+
+    private RunningVerifier verifier;
+
+    private void initVerifier(File root) throws VerificationException {
+        verifier = new RunningVerifier(root.getAbsolutePath());
+        verifier.setAutoclean(false);
+        verifier.setDebug(true);
+        verifier.setForkJvm(true);
+        verifier.setMavenDebug(true);
+        installPluginToLocalRepository(verifier.getLocalRepository());
+    }
+
+    @After
+    public void waitForStop() {
+        if (verifier != null) {
+            verifier.stop();
+        }
+        awaitUntilServerDown();
+    }
+
+    @Test
+    public void testRunWithoutClasses() throws Exception {
+        File testDir = initProject("projects/start-it", "projects/run-without-classes-it");
+        assertThat(testDir).isDirectory();
+
+        initVerifier(testDir);
+        prepareProject(testDir, verifier);
+
+        run(verifier, "clean");
+
+        String response = getHttpResponse();
+        assertThat(response).isEqualTo("aloha");
+    }
+
+    private void run(Verifier verifier, String ... previous) throws VerificationException {
+        verifier.setLogFileName("build-run.log");
+        ImmutableList.Builder<String> builder = ImmutableList.builder();
+        builder.add(previous);
+        builder.add("vertx:run");
+        verifier.executeGoals(builder.build());
+    }
+
+}

--- a/src/test/java/io/fabric8/vertx/maven/plugin/it/VertxMojoTestBase.java
+++ b/src/test/java/io/fabric8/vertx/maven/plugin/it/VertxMojoTestBase.java
@@ -76,6 +76,10 @@ public class VertxMojoTestBase {
     }
 
     public static File initProject(String name) {
+        return initProject(name, name);
+    }
+
+    public static File initProject(String name, String output) {
         File tc = new File("target/test-classes");
         if (!tc.isDirectory()) {
             tc.mkdirs();
@@ -86,7 +90,7 @@ public class VertxMojoTestBase {
             throw new RuntimeException("Cannot find directory: " + in.getAbsolutePath());
         }
 
-        File out = new File(tc, name);
+        File out = new File(tc, output);
         if (out.isDirectory()) {
             FileUtils.deleteQuietly(out);
         }
@@ -94,6 +98,10 @@ public class VertxMojoTestBase {
         try {
             System.out.println("Copying " + in.getAbsolutePath() + " to " + out.getParentFile().getAbsolutePath());
             FileUtils.copyDirectoryToDirectory(in, out.getParentFile());
+            File x = new File(out.getParentFile(), in.getName());
+            if (! x.getName().equals(out.getName())) {
+                x.renameTo(out);
+            }
         } catch (IOException e) {
             throw new RuntimeException("Cannot copy project resources", e);
         }


### PR DESCRIPTION
Run `mvn compile` (within the same maven execution) if the classes has not be compiled already

Also, improve the redeploy (trace, fix scan period)