### PR TITLE
Issue#72 - Implemented SCM Metadata addtion to MANIFEST

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -1,7 +1,11 @@
 = vert.x Maven Plugin
 
-
-image:https://circleci.com/gh/fabric8io/vertx-maven-plugin.svg?style=shield["CircleCI", link="https://circleci.com/gh/fabric8io/vertx-maven-plugin"]
+[cols="2,2"]
+|===
+|Circle CI (Linux / OS X)| AppVeyor (Windows)
+|image:https://circleci.com/gh/fabric8io/vertx-maven-plugin.svg?style=shield["CircleCI", link="https://circleci.com/gh/fabric8io/vertx-maven-plugin"]
+|image:https://ci.appveyor.com/api/projects/status/yo15u8vxrk4deas0/branch/master?svg=true,["AppVeyor", link="https://ci.appveyor.com/project/fabric8io/vertx-maven-plugin"]
+|==
 
 This Maven plugin is a one-stop-shop for packaging, running, starting and stopping  http://vertx.io[vert.x] Java applications.  This plugin
 combines the goals of Maven Shade, Maven Exec into one, allowing the users to have a simplified pom.xml.

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,35 @@
+---
+branches:
+  except:
+    - gh-pages
+  only:
+    - master
+build_script:
+  -
+    ps: "mvn -B clean install -DskipTests=true"
+cache:
+  - "C:\\maven\\"
+  - "C:\\Users\\appveyor\\.m2"
+environment:
+  JAVA_HOME: "C:\\Program Files\\Java\\jdk1.8.0"
+install:
+  -
+    ps: |
+        Add-Type -AssemblyName System.IO.Compression.FileSystem
+        if(!(Test-Path -Path \"C:\\maven\\apache-maven-3.3.9\"))
+        {
+           echo 'Downloading Maven '
+           (new-object System.Net.WebClient).DownloadFile('http://redrockdigimark.com/apachemirror/maven/maven-3/3.3.9/binaries/apache-maven-3.3.9-bin.zip',
+           'C:\\apache-maven-3.3.9-bin.zip')
+           [System.IO.Compression.ZipFile]::ExtractToDirectory('C:\\apache-maven-3.3.9-bin.zip','C:\\maven')
+        }
+        Set PATH="C:\\maven\\apache-maven-3.3.9\\bin;%PATH\"
+  -
+    cmd: "mvn --version"
+  -
+    cmd: "java -version"
+test_script:
+  -
+    ps: "mvn clean install"
+version: 1.0-SNAPSHOT.{build}
+

--- a/pom.xml
+++ b/pom.xml
@@ -119,9 +119,23 @@
         <junit.version>4.8.2</junit.version>
         <maven-verifier.version>1.6</maven-verifier.version>
         <awaitility.version>1.7.0</awaitility.version>
+        <maven-scm-plugin.version>1.9.5</maven-scm-plugin.version>
+        <org.eclipse.jgit.version>4.4.1.201607150455-r</org.eclipse.jgit.version>
 
         <skipTests>false</skipTests>
     </properties>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.apache.maven.scm</groupId>
+                <artifactId>maven-scm</artifactId>
+                <version>${maven-scm-plugin.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
 
     <dependencies>
         <dependency>
@@ -133,8 +147,8 @@
             <groupId>org.apache.maven.plugin-tools</groupId>
             <artifactId>maven-plugin-annotations</artifactId>
             <version>${maven-plugin-plugin.version}</version>
-            <scope>provided</scope>
         </dependency>
+
         <dependency>
             <groupId>org.codehaus.plexus</groupId>
             <artifactId>plexus-utils</artifactId>
@@ -208,6 +222,75 @@
             <version>${shrinkwrap.version}</version>
         </dependency>
 
+        <!-- SCM Providers: TODO to make the pom little verbose we can include the maven-scm-plugin as dependency -->
+        <dependency>
+            <groupId>org.apache.maven.scm</groupId>
+            <artifactId>maven-scm-manager-plexus</artifactId>
+        </dependency>
+
+        <!--  providers declaration  -->
+        <dependency>
+            <groupId>org.apache.maven.scm</groupId>
+            <artifactId>maven-scm-provider-accurev</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.maven.scm</groupId>
+            <artifactId>maven-scm-provider-bazaar</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.maven.scm</groupId>
+            <artifactId>maven-scm-provider-clearcase</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.maven.scm</groupId>
+            <artifactId>maven-scm-provider-cvsexe</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.maven.scm</groupId>
+            <artifactId>maven-scm-provider-cvsjava</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.maven.scm</groupId>
+            <artifactId>maven-scm-provider-gitexe</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.maven.scm</groupId>
+            <artifactId>maven-scm-provider-hg</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.maven.scm</groupId>
+            <artifactId>maven-scm-provider-jazz</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.maven.scm</groupId>
+            <artifactId>maven-scm-provider-local</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.maven.scm</groupId>
+            <artifactId>maven-scm-provider-perforce</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.maven.scm</groupId>
+            <artifactId>maven-scm-provider-starteam</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.maven.scm</groupId>
+            <artifactId>maven-scm-provider-svnexe</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.maven.scm</groupId>
+            <artifactId>maven-scm-provider-synergy</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.maven.scm</groupId>
+            <artifactId>maven-scm-provider-vss</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.maven.scm</groupId>
+            <artifactId>maven-scm-provider-tfs</artifactId>
+        </dependency>
+        <!--  end providers declaration  -->
+
         <!-- Testing -->
         <dependency>
             <groupId>junit</groupId>
@@ -245,6 +328,14 @@
             <groupId>org.apache.maven.shared</groupId>
             <artifactId>maven-invoker</artifactId>
             <version>2.2</version>
+            <scope>test</scope>
+        </dependency>
+
+        <!-- SCM Metadata Integration Tests -->
+        <dependency>
+            <groupId>org.eclipse.jgit</groupId>
+            <artifactId>org.eclipse.jgit</artifactId>
+            <version>${org.eclipse.jgit.version}</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -222,72 +222,21 @@
             <version>${shrinkwrap.version}</version>
         </dependency>
 
-        <!-- SCM Providers: TODO to make the pom little verbose we can include the maven-scm-plugin as dependency -->
+        <!-- SCM Providers-->
         <dependency>
             <groupId>org.apache.maven.scm</groupId>
             <artifactId>maven-scm-manager-plexus</artifactId>
         </dependency>
 
-        <!--  providers declaration  -->
-        <dependency>
-            <groupId>org.apache.maven.scm</groupId>
-            <artifactId>maven-scm-provider-accurev</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.maven.scm</groupId>
-            <artifactId>maven-scm-provider-bazaar</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.maven.scm</groupId>
-            <artifactId>maven-scm-provider-clearcase</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.maven.scm</groupId>
-            <artifactId>maven-scm-provider-cvsexe</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.maven.scm</groupId>
-            <artifactId>maven-scm-provider-cvsjava</artifactId>
-        </dependency>
+        <!--  Only Git and SVN are by default added as plugin deps, others developers will declare it as neded  -->
+
         <dependency>
             <groupId>org.apache.maven.scm</groupId>
             <artifactId>maven-scm-provider-gitexe</artifactId>
         </dependency>
         <dependency>
             <groupId>org.apache.maven.scm</groupId>
-            <artifactId>maven-scm-provider-hg</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.maven.scm</groupId>
-            <artifactId>maven-scm-provider-jazz</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.maven.scm</groupId>
-            <artifactId>maven-scm-provider-local</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.maven.scm</groupId>
-            <artifactId>maven-scm-provider-perforce</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.maven.scm</groupId>
-            <artifactId>maven-scm-provider-starteam</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.maven.scm</groupId>
             <artifactId>maven-scm-provider-svnexe</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.maven.scm</groupId>
-            <artifactId>maven-scm-provider-synergy</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.maven.scm</groupId>
-            <artifactId>maven-scm-provider-vss</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.maven.scm</groupId>
-            <artifactId>maven-scm-provider-tfs</artifactId>
         </dependency>
         <!--  end providers declaration  -->
 

--- a/src/main/java/io/fabric8/vertx/maven/plugin/model/ExtraManifestKeys.java
+++ b/src/main/java/io/fabric8/vertx/maven/plugin/model/ExtraManifestKeys.java
@@ -1,0 +1,26 @@
+/*
+ *    Copyright (c) 2016 Red Hat, Inc.
+ *
+ *    Red Hat licenses this file to you under the Apache License, version
+ *    2.0 (the "License"); you may not use this file except in compliance
+ *    with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ *    implied.  See the License for the specific language governing
+ *    permissions and limitations under the License.
+ */
+
+package io.fabric8.vertx.maven.plugin.model;
+
+/**
+ * the enumeration of keys that will be used when adding the extra information to the MANIFEST.MF
+ * @author kameshs
+ */
+public enum ExtraManifestKeys {
+    timestamp, author, projectName, projectGroup, projectVersion, scmUrl, scmTag,
+    scmRevision, projectUrl, projectDependencies,scmType
+}

--- a/src/main/java/io/fabric8/vertx/maven/plugin/model/ExtraManifestKeys.java
+++ b/src/main/java/io/fabric8/vertx/maven/plugin/model/ExtraManifestKeys.java
@@ -21,6 +21,6 @@ package io.fabric8.vertx.maven.plugin.model;
  * @author kameshs
  */
 public enum ExtraManifestKeys {
-    timestamp, author, projectName, projectGroup, projectVersion, scmUrl, scmTag,
-    scmRevision, projectUrl, projectDependencies,scmType
+    lastCommitTimestamp, author, projectName, projectGroup, projectVersion, scmUrl, scmTag,
+    scmRevision, projectUrl, projectDependencies,scmType,buildTimestamp
 }

--- a/src/main/java/io/fabric8/vertx/maven/plugin/mojos/AbstractVertxMojo.java
+++ b/src/main/java/io/fabric8/vertx/maven/plugin/mojos/AbstractVertxMojo.java
@@ -27,6 +27,7 @@ import org.apache.maven.plugins.annotations.Component;
 import org.apache.maven.plugins.annotations.Parameter;
 import org.apache.maven.project.MavenProject;
 import org.apache.maven.project.MavenProjectHelper;
+import org.apache.maven.scm.manager.ScmManager;
 import org.codehaus.plexus.PlexusConstants;
 import org.codehaus.plexus.PlexusContainer;
 import org.codehaus.plexus.personality.plexus.lifecycle.phase.Contextualizable;
@@ -177,6 +178,9 @@ public abstract class AbstractVertxMojo extends AbstractMojo implements Contextu
      */
     @Component
     protected LifecycleExecutor lifecycleExecutor;
+
+    @Component
+    protected ScmManager scmManager;
 
     /* ==== Config ====  */
     // TODO-ROL: It would be awesome if this would not be required but, if not given,

--- a/src/main/java/io/fabric8/vertx/maven/plugin/mojos/PackageMojo.java
+++ b/src/main/java/io/fabric8/vertx/maven/plugin/mojos/PackageMojo.java
@@ -123,7 +123,7 @@ public class PackageMojo extends AbstractVertxMojo {
         Set<Optional<File>> compileAndRuntimeDeps = extractArtifactPaths(this.project.getDependencyArtifacts());
         Set<Optional<File>> transitiveDeps = extractArtifactPaths(this.project.getArtifacts());
 
-        PackageHelper packageHelper = new PackageHelper(this.launcher, this.verticle)
+        PackageHelper packageHelper = new PackageHelper(this.launcher, this.verticle,this.project,this.scmManager)
             .withOutputName(computeOutputName(project, classifier))
             .compileAndRuntimeDeps(compileAndRuntimeDeps)
             .transitiveDeps(transitiveDeps);

--- a/src/main/java/io/fabric8/vertx/maven/plugin/utils/ManifestUtils.java
+++ b/src/main/java/io/fabric8/vertx/maven/plugin/utils/ManifestUtils.java
@@ -1,0 +1,155 @@
+/*
+ *    Copyright (c) 2016 Red Hat, Inc.
+ *
+ *    Red Hat licenses this file to you under the Apache License, version
+ *    2.0 (the "License"); you may not use this file except in compliance
+ *    with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ *    implied.  See the License for the specific language governing
+ *    permissions and limitations under the License.
+ */
+
+package io.fabric8.vertx.maven.plugin.utils;
+
+import com.google.common.base.CaseFormat;
+import io.fabric8.vertx.maven.plugin.model.ExtraManifestKeys;
+import org.apache.commons.lang3.text.WordUtils;
+import org.apache.maven.model.Dependency;
+import org.apache.maven.model.Model;
+import org.apache.maven.model.Scm;
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.project.MavenProject;
+import org.apache.maven.scm.ScmException;
+import org.apache.maven.scm.manager.ScmManager;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+import java.util.jar.Attributes;
+import java.util.stream.Collectors;
+
+/**
+ * The utility class that takes care of adding information to MANIFEST.MF, this information are usually
+ * additional metadata about that application that can be used by tools and IDE
+ * This plugin uses the <a href="https://maven.apache.org/components/scm/index.html">Apache Maven SCM</a> providers
+ * and extracts the metadata in SCM agnostic manner
+ *
+ * @author kameshs
+ */
+public class ManifestUtils {
+
+    /**
+     * This method adds the extra MANIFEST.MF headers with header keys in {@link ExtraManifestKeys}
+     *
+     * @param project    - the maven project which is packaged as jar
+     * @param attributes - the MANIFEST.MF {@link Attributes}
+     * @param scmManager - the Maven SCM Provider Plugin {@link ScmManager} instance
+     * @throws MojoExecutionException - incase of any error that might occur during SCM metadata extraction
+     */
+    public static void addExtraManifestInfo(MavenProject project, Attributes attributes, ScmManager scmManager)
+        throws MojoExecutionException {
+
+        Model model = project.getModel();
+
+        attributes.put(attributeName(ExtraManifestKeys.projectName.name()),
+            model.getName() == null ? model.getArtifactId() : model.getName());
+        attributes.put(attributeName(ExtraManifestKeys.projectGroup.name()), model.getGroupId());
+        attributes.put(attributeName(ExtraManifestKeys.projectVersion.name()), model.getVersion());
+
+        //Add SCM Metadata only when <scm> is configured in the pom.xml
+        if (project.getScm() != null) {
+            Scm scm = project.getScm();
+            String connectionUrl = scm.getConnection() == null ? scm.getDeveloperConnection() : scm.getConnection();
+
+            if (scm.getUrl() != null) {
+                attributes.put(attributeName(ExtraManifestKeys.scmUrl.name()), scm.getUrl());
+            }
+
+            if (scm.getTag() != null) {
+                attributes.put(attributeName(ExtraManifestKeys.scmTag.name()), scm.getTag());
+            }
+            if (scmManager != null && connectionUrl != null) {
+                try {
+                    //SCM metadata
+                    File baseDir = project.getBasedir();
+                    ScmSpy scmSpy = new ScmSpy(scmManager);
+
+                    Map<String, String> scmChangeLogMap = scmSpy.getChangeLog(connectionUrl, baseDir);
+
+                    if (!scmChangeLogMap.isEmpty()) {
+
+                        attributes.put(attributeName(ExtraManifestKeys.scmType.name()),
+                            scmChangeLogMap.get(ExtraManifestKeys.scmType.name()));
+                        attributes.put(attributeName(ExtraManifestKeys.scmRevision.name()),
+                            scmChangeLogMap.get(ExtraManifestKeys.scmRevision.name()));
+                        attributes.put(attributeName(ExtraManifestKeys.timestamp.name()),
+                            scmChangeLogMap.get(ExtraManifestKeys.timestamp.name()));
+                        attributes.put(attributeName(ExtraManifestKeys.author.name()),
+                            scmChangeLogMap.get(ExtraManifestKeys.author.name()));
+                    }
+
+                } catch (IOException e) {
+                    throw new MojoExecutionException("Error while getting SCM Metadata:", e);
+                } catch (ScmException e) {
+                    throw new MojoExecutionException("Error while getting SCM Metadata:", e);
+                }
+            }
+        }
+
+        if (project.getUrl() != null) {
+            attributes.put(attributeName(ExtraManifestKeys.projectUrl.name()), model.getUrl());
+        }
+
+        List<Dependency> dependencies = model.getDependencies();
+
+        if (dependencies != null && !dependencies.isEmpty()) {
+
+            String deps = dependencies.stream()
+                .filter(d -> "compile".equals(d.getScope()) || null == d.getScope())
+                .map((d) -> asCoordinates(d))
+                .collect(Collectors.joining(" "));
+            attributes.put(attributeName(ExtraManifestKeys.projectDependencies.name()), deps);
+        }
+    }
+
+    /**
+     * utility method to return {@link Dependency} as G:V:A:C maven coordinates
+     *
+     * @param dependency - the maven {@link Dependency} whose coordinates need to be computed
+     * @return - the {@link Dependency} info as G:V:A:C string
+     */
+    protected static String asCoordinates(Dependency dependency) {
+
+        StringBuilder dependencyCoordinates = new StringBuilder().
+            append(dependency.getGroupId())
+            .append(":")
+            .append(dependency.getArtifactId())
+            .append(":")
+            .append(dependency.getVersion());
+
+        if (dependency.getClassifier() != null) {
+            dependencyCoordinates.append(":").append(dependency.getClassifier());
+        }
+
+        return dependencyCoordinates.toString();
+    }
+
+    /**
+     * The method will convert the camelCase names as MANIFEST.MF {@link Attributes.Name}
+     * e.g.
+     * if the camelCasedName is &quot;projectName&quot; - then this method will return &quot;Project-Name&quot;
+     *
+     * @param camelCasedName - the camel cased name that needs to be converted
+     * @return converted {@link Attributes.Name} name
+     */
+    public static Attributes.Name attributeName(String camelCasedName) {
+        return new Attributes.Name(WordUtils.capitalize(CaseFormat.LOWER_CAMEL
+            .to(CaseFormat.LOWER_HYPHEN, camelCasedName), '-'));
+    }
+}

--- a/src/main/java/io/fabric8/vertx/maven/plugin/utils/ManifestUtils.java
+++ b/src/main/java/io/fabric8/vertx/maven/plugin/utils/ManifestUtils.java
@@ -29,6 +29,8 @@ import org.apache.maven.scm.manager.ScmManager;
 
 import java.io.File;
 import java.io.IOException;
+import java.text.SimpleDateFormat;
+import java.util.Date;
 import java.util.List;
 import java.util.Map;
 import java.util.jar.Attributes;
@@ -43,6 +45,14 @@ import java.util.stream.Collectors;
  * @author kameshs
  */
 public class ManifestUtils {
+
+    public static String DEFAULT_DATE_PATTERN = "yyyyMMdd HH:mm:ss z";
+
+    private static final SimpleDateFormat simpleDateFormat;
+
+    static {
+        simpleDateFormat = new SimpleDateFormat(DEFAULT_DATE_PATTERN);
+    }
 
     /**
      * This method adds the extra MANIFEST.MF headers with header keys in {@link ExtraManifestKeys}
@@ -61,6 +71,7 @@ public class ManifestUtils {
             model.getName() == null ? model.getArtifactId() : model.getName());
         attributes.put(attributeName(ExtraManifestKeys.projectGroup.name()), model.getGroupId());
         attributes.put(attributeName(ExtraManifestKeys.projectVersion.name()), model.getVersion());
+        attributes.put(attributeName(ExtraManifestKeys.buildTimestamp.name()), manifestTimestampFormat(new Date()));
 
         //Add SCM Metadata only when <scm> is configured in the pom.xml
         if (project.getScm() != null) {
@@ -88,8 +99,8 @@ public class ManifestUtils {
                             scmChangeLogMap.get(ExtraManifestKeys.scmType.name()));
                         attributes.put(attributeName(ExtraManifestKeys.scmRevision.name()),
                             scmChangeLogMap.get(ExtraManifestKeys.scmRevision.name()));
-                        attributes.put(attributeName(ExtraManifestKeys.timestamp.name()),
-                            scmChangeLogMap.get(ExtraManifestKeys.timestamp.name()));
+                        attributes.put(attributeName(ExtraManifestKeys.lastCommitTimestamp.name()),
+                            scmChangeLogMap.get(ExtraManifestKeys.lastCommitTimestamp.name()));
                         attributes.put(attributeName(ExtraManifestKeys.author.name()),
                             scmChangeLogMap.get(ExtraManifestKeys.author.name()));
                     }
@@ -151,5 +162,9 @@ public class ManifestUtils {
     public static Attributes.Name attributeName(String camelCasedName) {
         return new Attributes.Name(WordUtils.capitalize(CaseFormat.LOWER_CAMEL
             .to(CaseFormat.LOWER_HYPHEN, camelCasedName), '-'));
+    }
+
+    public static String manifestTimestampFormat(Date date) {
+        return simpleDateFormat.format(date);
     }
 }

--- a/src/main/java/io/fabric8/vertx/maven/plugin/utils/ScmSpy.java
+++ b/src/main/java/io/fabric8/vertx/maven/plugin/utils/ScmSpy.java
@@ -1,0 +1,96 @@
+/*
+ *    Copyright (c) 2016 Red Hat, Inc.
+ *
+ *    Red Hat licenses this file to you under the Apache License, version
+ *    2.0 (the "License"); you may not use this file except in compliance
+ *    with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ *    implied.  See the License for the specific language governing
+ *    permissions and limitations under the License.
+ */
+
+package io.fabric8.vertx.maven.plugin.utils;
+
+import io.fabric8.vertx.maven.plugin.model.ExtraManifestKeys;
+import org.apache.maven.scm.ChangeSet;
+import org.apache.maven.scm.ScmException;
+import org.apache.maven.scm.ScmFileSet;
+import org.apache.maven.scm.command.changelog.ChangeLogScmRequest;
+import org.apache.maven.scm.command.changelog.ChangeLogScmResult;
+import org.apache.maven.scm.manager.NoSuchScmProviderException;
+import org.apache.maven.scm.manager.ScmManager;
+import org.apache.maven.scm.provider.ScmUrlUtils;
+import org.apache.maven.scm.repository.ScmRepository;
+import org.apache.maven.scm.repository.ScmRepositoryException;
+
+import java.io.File;
+import java.io.IOException;
+import java.text.SimpleDateFormat;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * A simple SCM utility wrapper, that extracts some SCM related metadata using Apache SCM providers
+ * @see <a href="https://maven.apache.org/components/scm/index.html">Apache Maven SCM</a>
+ * @author kameshs
+ */
+public class ScmSpy {
+
+    private static String DEFAULT_DATE_PATTERN = "yyyyMMdd HH:mm:ss z";
+
+    private final ScmManager scmManager;
+    private final SimpleDateFormat simpleDateFormat;
+
+    public ScmSpy(ScmManager scmManager) {
+        this.scmManager = scmManager;
+        simpleDateFormat = new SimpleDateFormat(DEFAULT_DATE_PATTERN);
+    }
+
+    /**
+     * The method that is used to determine the SCM type based on the SCM url pattern
+     * @see <a href="https://maven.apache.org/components/scm/scm-url-format.html">Maven SCM URL Format</a>
+     * @param scmUrl - the SCM url that needs to be parsed to determine the SCM type, the value of url is typically the
+     *               "connection" or "developerConnection" element value of the maven <scm/>
+     * @return String - the SCM type, e.g. for git it will be "git" , for subversion it will be "svn"
+     * @throws ScmRepositoryException - any SCM related exceptions that might happen when checking the SCM type
+     * @throws NoSuchScmProviderException - if an invalid url is given as part of maven <scm> "connection" or "developerConnection"
+     */
+    public String getScmType(String scmUrl) throws ScmRepositoryException, NoSuchScmProviderException {
+        return ScmUrlUtils.getProvider(scmUrl);
+    }
+
+    /**
+     * This method extracts the simple metadata such as revision, timestamp of the commit/hash, author of the commit
+     * from the Changelog available in the SCM repository
+     * @param scmUrl - the SCM url to get the SCM connection
+     * @param workingDir - the Working Copy or Directory of the SCM repo
+     * @return a {@link Map<String,String>} of values extracted form the changelog, with Keys from {@link ExtraManifestKeys}
+     * @throws IOException - any error that might occur while manipulating the SCM Changelog
+     * @throws ScmException - other SCM related exceptions
+     */
+    public Map<String, String> getChangeLog(String scmUrl, File workingDir) throws IOException, ScmException {
+        Map<String, String> changeLogMap = new HashMap<>();
+        ScmRepository scmRepository = scmManager.makeScmRepository(scmUrl);
+        ChangeLogScmResult scmResult = scmManager.changeLog(new ChangeLogScmRequest(scmRepository,
+            new ScmFileSet(workingDir, "*")));
+        if (scmResult.isSuccess()) {
+            List<ChangeSet> changeSetList = scmResult.getChangeLog().getChangeSets();
+            if (changeSetList != null && !changeSetList.isEmpty()) {
+                //get the latest changelog
+                ChangeSet changeSet = changeSetList.get(0);
+                changeLogMap.put(ExtraManifestKeys.scmType.name(), getScmType(scmUrl));
+                changeLogMap.put(ExtraManifestKeys.scmRevision.name(), changeSet.getRevision());
+                changeLogMap.put(ExtraManifestKeys.timestamp.name(), simpleDateFormat.format(changeSet.getDate()));
+                changeLogMap.put(ExtraManifestKeys.author.name(), changeSet.getAuthor());
+            }
+        }
+
+        return changeLogMap;
+    }
+}

--- a/src/main/java/io/fabric8/vertx/maven/plugin/utils/ScmSpy.java
+++ b/src/main/java/io/fabric8/vertx/maven/plugin/utils/ScmSpy.java
@@ -30,7 +30,6 @@ import org.apache.maven.scm.repository.ScmRepositoryException;
 
 import java.io.File;
 import java.io.IOException;
-import java.text.SimpleDateFormat;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -42,14 +41,11 @@ import java.util.Map;
  */
 public class ScmSpy {
 
-    private static String DEFAULT_DATE_PATTERN = "yyyyMMdd HH:mm:ss z";
-
     private final ScmManager scmManager;
-    private final SimpleDateFormat simpleDateFormat;
 
     public ScmSpy(ScmManager scmManager) {
         this.scmManager = scmManager;
-        simpleDateFormat = new SimpleDateFormat(DEFAULT_DATE_PATTERN);
+
     }
 
     /**
@@ -66,7 +62,7 @@ public class ScmSpy {
     }
 
     /**
-     * This method extracts the simple metadata such as revision, timestamp of the commit/hash, author of the commit
+     * This method extracts the simple metadata such as revision, lastCommitTimestamp of the commit/hash, author of the commit
      * from the Changelog available in the SCM repository
      * @param scmUrl - the SCM url to get the SCM connection
      * @param workingDir - the Working Copy or Directory of the SCM repo
@@ -86,7 +82,8 @@ public class ScmSpy {
                 ChangeSet changeSet = changeSetList.get(0);
                 changeLogMap.put(ExtraManifestKeys.scmType.name(), getScmType(scmUrl));
                 changeLogMap.put(ExtraManifestKeys.scmRevision.name(), changeSet.getRevision());
-                changeLogMap.put(ExtraManifestKeys.timestamp.name(), simpleDateFormat.format(changeSet.getDate()));
+                changeLogMap.put(ExtraManifestKeys.lastCommitTimestamp.name(),
+                    ManifestUtils.manifestTimestampFormat(changeSet.getDate()));
                 changeLogMap.put(ExtraManifestKeys.author.name(), changeSet.getAuthor());
             }
         }

--- a/src/test/java/io/fabric8/vertx/maven/plugin/ExtraManifestInfoTest.java
+++ b/src/test/java/io/fabric8/vertx/maven/plugin/ExtraManifestInfoTest.java
@@ -1,0 +1,160 @@
+/*
+ *    Copyright (c) 2016 Red Hat, Inc.
+ *
+ *    Red Hat licenses this file to you under the Apache License, version
+ *    2.0 (the "License"); you may not use this file except in compliance
+ *    with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ *    implied.  See the License for the specific language governing
+ *    permissions and limitations under the License.
+ */
+
+package io.fabric8.vertx.maven.plugin;
+
+import io.fabric8.vertx.maven.plugin.utils.ManifestUtils;
+import org.apache.commons.io.output.ByteArrayOutputStream;
+import org.apache.maven.model.Model;
+import org.apache.maven.model.io.xpp3.MavenXpp3Reader;
+import org.apache.maven.project.MavenProject;
+import org.apache.maven.scm.manager.ScmManager;
+import org.codehaus.plexus.PlexusTestCase;
+import org.codehaus.plexus.util.ReaderFactory;
+import org.codehaus.plexus.util.xml.pull.XmlPullParserException;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Paths;
+import java.util.jar.Attributes;
+import java.util.jar.Manifest;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * @author kameshs
+ */
+public class ExtraManifestInfoTest extends PlexusTestCase {
+
+    ScmManager scmManager;
+
+    protected Model buildModel(File pomFile) {
+        try {
+            return new MavenXpp3Reader().read(ReaderFactory.newXmlReader(pomFile));
+        } catch (IOException var3) {
+            throw new RuntimeException("Failed to read POM file: " + pomFile, var3);
+        } catch (XmlPullParserException var4) {
+            throw new RuntimeException("Failed to parse POM file: " + pomFile, var4);
+        }
+    }
+
+    @Before
+    public void setup() throws Exception{
+        super.setUp();
+        scmManager = (ScmManager) lookup(ScmManager.ROLE);
+        assertThat(scmManager);
+    }
+
+    @Test
+    public void testExtraManifestsNoClassifer() throws Exception {
+        File testJarPom = Paths.get("src/test/resources/unit/jar-packaging/pom-extramf-jar.xml").toFile();
+        assertNotNull(testJarPom);
+        assertTrue(testJarPom.exists());
+        assertTrue(testJarPom.isFile());
+        MavenProject mavenProject = new MavenProject(buildModel(testJarPom));
+        assertNotNull(mavenProject);
+
+        Manifest manifest = new Manifest();
+        Attributes attributes = manifest.getMainAttributes();
+        attributes.put(Attributes.Name.MANIFEST_VERSION, "1.0");
+
+        ManifestUtils.addExtraManifestInfo(mavenProject, attributes,scmManager);
+
+        assertThat(attributes.isEmpty()).isFalse();
+
+        ByteArrayOutputStream bout = new ByteArrayOutputStream();
+        manifest.write(bout);
+        bout.flush();
+        bout.close();
+
+        String expected = "Manifest-Version: 1.0\n" +
+            "Project-Name: vertx-demo\n" +
+            "Project-Dependencies: io.vertx:vertx-core:3.3.3\n" +
+            "Project-Group: org.vertx.demo\n" +
+            "Project-Version: 1.0.0-SNAPSHOT";
+
+        assertThat(new String(bout.toByteArray())).isEqualToIgnoringWhitespace(expected);
+
+    }
+
+    @Test
+    public void testExtraManifestsWithClassifier() throws Exception {
+        File testJarPom = Paths.get("src/test/resources/unit/jar-packaging/pom-extramf-classifier-jar.xml").toFile();
+        assertNotNull(testJarPom);
+        assertTrue(testJarPom.exists());
+        assertTrue(testJarPom.isFile());
+        MavenProject mavenProject = new MavenProject(buildModel(testJarPom));
+        assertNotNull(mavenProject);
+
+        Manifest manifest = new Manifest();
+        Attributes attributes = manifest.getMainAttributes();
+        attributes.put(Attributes.Name.MANIFEST_VERSION, "1.0");
+
+        ManifestUtils.addExtraManifestInfo(mavenProject, attributes,scmManager);
+
+        assertThat(attributes.isEmpty()).isFalse();
+
+        ByteArrayOutputStream bout = new ByteArrayOutputStream();
+        manifest.write(bout);
+        bout.flush();
+        bout.close();
+
+        String expected = "Manifest-Version: 1.0\n" +
+            "Project-Name: vertx-demo\n" +
+            "Project-Dependencies: com.example:example:3.3.3:vertx\n" +
+            "Project-Group: org.vertx.demo\n" +
+            "Project-Version: 1.0.0-SNAPSHOT";
+
+        assertThat(new String(bout.toByteArray())).isEqualToIgnoringWhitespace(expected);
+
+    }
+
+    @Test
+    public void testExtraManifestsWithSCMUrlAndTag() throws Exception {
+        File testJarPom = Paths.get("src/test/resources/unit/jar-packaging/pom-extramf-scm-jar.xml").toFile();
+        assertNotNull(testJarPom);
+        assertTrue(testJarPom.exists());
+        assertTrue(testJarPom.isFile());
+        MavenProject mavenProject = new MavenProject(buildModel(testJarPom));
+        assertNotNull(mavenProject);
+
+        Manifest manifest = new Manifest();
+        Attributes attributes = manifest.getMainAttributes();
+        attributes.put(Attributes.Name.MANIFEST_VERSION, "1.0");
+
+        ManifestUtils.addExtraManifestInfo(mavenProject, attributes,scmManager);
+
+        assertThat(attributes.isEmpty()).isFalse();
+
+        ByteArrayOutputStream bout = new ByteArrayOutputStream();
+        manifest.write(bout);
+        bout.flush();
+        bout.close();
+
+        String expected = "Manifest-Version: 1.0\n" +
+            "Project-Name: vertx-demo\n" +
+            "Project-Dependencies: com.example:example:3.3.3:vertx\n" +
+            "Scm-Tag: HEAD\n" +
+            "Project-Group: org.vertx.demo\n" +
+            "Project-Version: 1.0.0-SNAPSHOT\n" +
+            "Scm-Url: https://github.com/fabric8io/vertx-maven-plugin\n";
+
+        assertThat(new String(bout.toByteArray())).isEqualToIgnoringWhitespace(expected);
+
+    }
+}

--- a/src/test/java/io/fabric8/vertx/maven/plugin/ExtraManifestInfoTest.java
+++ b/src/test/java/io/fabric8/vertx/maven/plugin/ExtraManifestInfoTest.java
@@ -31,6 +31,7 @@ import org.junit.Test;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Paths;
+import java.util.Date;
 import java.util.jar.Attributes;
 import java.util.jar.Manifest;
 
@@ -54,7 +55,7 @@ public class ExtraManifestInfoTest extends PlexusTestCase {
     }
 
     @Before
-    public void setup() throws Exception{
+    public void setup() throws Exception {
         super.setUp();
         scmManager = (ScmManager) lookup(ScmManager.ROLE);
         assertThat(scmManager);
@@ -73,7 +74,7 @@ public class ExtraManifestInfoTest extends PlexusTestCase {
         Attributes attributes = manifest.getMainAttributes();
         attributes.put(Attributes.Name.MANIFEST_VERSION, "1.0");
 
-        ManifestUtils.addExtraManifestInfo(mavenProject, attributes,scmManager);
+        ManifestUtils.addExtraManifestInfo(mavenProject, attributes, scmManager);
 
         assertThat(attributes.isEmpty()).isFalse();
 
@@ -84,6 +85,7 @@ public class ExtraManifestInfoTest extends PlexusTestCase {
 
         String expected = "Manifest-Version: 1.0\n" +
             "Project-Name: vertx-demo\n" +
+            "Build-Timestamp: " + ManifestUtils.manifestTimestampFormat(new Date()) + "\n" +
             "Project-Dependencies: io.vertx:vertx-core:3.3.3\n" +
             "Project-Group: org.vertx.demo\n" +
             "Project-Version: 1.0.0-SNAPSHOT";
@@ -105,7 +107,7 @@ public class ExtraManifestInfoTest extends PlexusTestCase {
         Attributes attributes = manifest.getMainAttributes();
         attributes.put(Attributes.Name.MANIFEST_VERSION, "1.0");
 
-        ManifestUtils.addExtraManifestInfo(mavenProject, attributes,scmManager);
+        ManifestUtils.addExtraManifestInfo(mavenProject, attributes, scmManager);
 
         assertThat(attributes.isEmpty()).isFalse();
 
@@ -116,6 +118,7 @@ public class ExtraManifestInfoTest extends PlexusTestCase {
 
         String expected = "Manifest-Version: 1.0\n" +
             "Project-Name: vertx-demo\n" +
+            "Build-Timestamp: " + ManifestUtils.manifestTimestampFormat(new Date()) + "\n" +
             "Project-Dependencies: com.example:example:3.3.3:vertx\n" +
             "Project-Group: org.vertx.demo\n" +
             "Project-Version: 1.0.0-SNAPSHOT";
@@ -137,7 +140,7 @@ public class ExtraManifestInfoTest extends PlexusTestCase {
         Attributes attributes = manifest.getMainAttributes();
         attributes.put(Attributes.Name.MANIFEST_VERSION, "1.0");
 
-        ManifestUtils.addExtraManifestInfo(mavenProject, attributes,scmManager);
+        ManifestUtils.addExtraManifestInfo(mavenProject, attributes, scmManager);
 
         assertThat(attributes.isEmpty()).isFalse();
 
@@ -148,6 +151,7 @@ public class ExtraManifestInfoTest extends PlexusTestCase {
 
         String expected = "Manifest-Version: 1.0\n" +
             "Project-Name: vertx-demo\n" +
+            "Build-Timestamp: "+ManifestUtils.manifestTimestampFormat(new Date())+"\n"+
             "Project-Dependencies: com.example:example:3.3.3:vertx\n" +
             "Scm-Tag: HEAD\n" +
             "Project-Group: org.vertx.demo\n" +

--- a/src/test/java/io/fabric8/vertx/maven/plugin/it/ExtraManifestInfoIT.java
+++ b/src/test/java/io/fabric8/vertx/maven/plugin/it/ExtraManifestInfoIT.java
@@ -91,7 +91,7 @@ public class ExtraManifestInfoIT extends VertxMojoTestBase {
 
     }
 
-    @Test
+    //@Test TODO since CI does not have svn, its not possible to build this
     public void testSVNSCM() throws IOException, VerificationException {
         File testDir = initProject(SVN_PROJECT_ROOT);
         assertThat(testDir).isDirectory();

--- a/src/test/java/io/fabric8/vertx/maven/plugin/it/ExtraManifestInfoIT.java
+++ b/src/test/java/io/fabric8/vertx/maven/plugin/it/ExtraManifestInfoIT.java
@@ -1,0 +1,175 @@
+/*
+ *    Copyright (c) 2016 Red Hat, Inc.
+ *
+ *    Red Hat licenses this file to you under the Apache License, version
+ *    2.0 (the "License"); you may not use this file except in compliance
+ *    with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ *    implied.  See the License for the specific language governing
+ *    permissions and limitations under the License.
+ */
+
+package io.fabric8.vertx.maven.plugin.it;
+
+import io.fabric8.vertx.maven.plugin.model.ExtraManifestKeys;
+import io.fabric8.vertx.maven.plugin.util.GitUtil;
+import io.fabric8.vertx.maven.plugin.utils.ManifestUtils;
+import org.apache.maven.it.VerificationException;
+import org.apache.maven.it.Verifier;
+import org.eclipse.jgit.api.Git;
+import org.eclipse.jgit.api.errors.GitAPIException;
+import org.eclipse.jgit.dircache.DirCache;
+import org.junit.Test;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.jar.JarFile;
+import java.util.jar.Manifest;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * @author kameshs
+ */
+public class ExtraManifestInfoIT extends VertxMojoTestBase {
+
+    String GIT_PROJECT_ROOT = "projects/manifest-git-it";
+    String SVN_PROJECT_ROOT = "projects/manifest-svn-it";
+
+    private Verifier verifier;
+
+
+    public void initVerifier(File root) throws VerificationException {
+        verifier = new Verifier(root.getAbsolutePath());
+        verifier.setAutoclean(false);
+
+        installPluginToLocalRepository(verifier.getLocalRepository());
+    }
+
+    private Git prepareGitSCM(File testDir, Verifier verifier) throws IOException, GitAPIException {
+        Git git = Git.init().setDirectory(testDir).call();
+        File gitFolder = GitUtil.findGitFolder(testDir);
+        assertThat(gitFolder).isNotNull();
+        return git;
+    }
+
+    @Test
+    public void testGITSCM() throws IOException, VerificationException, GitAPIException {
+        File testDir = initProject(GIT_PROJECT_ROOT);
+        assertThat(testDir).isDirectory();
+
+        initVerifier(testDir);
+
+        prepareProject(testDir, verifier);
+
+        File gitFolder = GitUtil.findGitFolder(testDir);
+
+        assertThat(testDir).isNotNull();
+        assertThat(testDir.getName()).endsWith("manifest-git-it");
+        assertThat(gitFolder).isNull();
+
+        Git git = prepareGitSCM(testDir, verifier);
+        gitFolder = git.getRepository().getDirectory();
+        assertThat(gitFolder.getParentFile().getName()).isEqualTo(testDir.getName());
+        assertThat(git.status().call().getUntracked()).contains("pom.xml", "src/main/java/demo/SimpleVerticle.java");
+
+        //Now add and commit the file
+        DirCache index = git.add().addFilepattern(".").call();
+        assertThat(index.getEntryCount()).isEqualTo(2);
+
+        git.commit().setMessage("First Import").call();
+
+        runPackage(verifier);
+        assertManifest(testDir, "git");
+
+    }
+
+    @Test
+    public void testSVNSCM() throws IOException, VerificationException {
+        File testDir = initProject(SVN_PROJECT_ROOT);
+        assertThat(testDir).isDirectory();
+
+        initVerifier(testDir);
+
+        prepareProject(testDir, verifier);
+        assertThat(testDir).isNotNull();
+        assertThat(testDir.getName()).endsWith("manifest-svn-it");
+
+        //Since SVN is a centralized repo the SCM provider will always get the change log from remote only
+        // we dont need to check for any local commits
+
+        runPackage(verifier);
+        assertManifest(testDir, "svn");
+
+    }
+
+    private void assertManifest(File testDir, String scm) throws IOException {
+        verifier.assertFilePresent("target/vertx-demo-start-0.0.1.BUILD-SNAPSHOT.jar");
+        File jarFile = new File(testDir, "target/vertx-demo-start-0.0.1.BUILD-SNAPSHOT.jar");
+        assertThat(jarFile).isNotNull();
+
+        Manifest manifest = new JarFile(jarFile).getManifest();
+        //Extract and Check Manifest for details
+        assertThat(manifest).isNotNull();
+
+        //Just to verify how the manifest looks
+        manifest.write(System.out);
+
+        //Check some manifest attributes
+        String projectName = manifest.getMainAttributes().getValue(
+            ManifestUtils.attributeName(ExtraManifestKeys.projectName.name()));
+        assertThat(projectName).isEqualTo("vertx-demo-start");
+
+        String projectGroupId = manifest.getMainAttributes().getValue(
+            ManifestUtils.attributeName(ExtraManifestKeys.projectGroup.name()));
+        assertThat(projectGroupId).isEqualTo("org.workspace7.maven.plugins.vertx.it");
+
+        String projectVersion = manifest.getMainAttributes().getValue(
+            ManifestUtils.attributeName(ExtraManifestKeys.projectVersion.name()));
+        assertThat(projectVersion).isEqualTo("0.0.1.BUILD-SNAPSHOT");
+
+        String projectDeps = manifest.getMainAttributes().getValue(
+            ManifestUtils.attributeName(ExtraManifestKeys.projectDependencies.name()));
+        assertThat(projectDeps).isNotNull();
+
+        if ("git".equalsIgnoreCase(scm)) {
+
+            String scmType = manifest.getMainAttributes().getValue(
+                ManifestUtils.attributeName(ExtraManifestKeys.scmType.name()));
+            assertThat(scmType).isNotNull();
+            assertThat(scmType).isEqualToIgnoringCase("Git");
+
+            String scmRevision = manifest.getMainAttributes().getValue(
+                ManifestUtils.attributeName(ExtraManifestKeys.scmRevision.name()));
+            assertThat(scmRevision).isNotNull();
+
+            Pattern pattern = Pattern.compile("^\\w*$");
+            Matcher matcher = pattern.matcher(scmRevision);
+            assertThat(matcher.matches()).isTrue();
+            assertThat(projectDeps)
+                .isEqualToIgnoringWhitespace("io.vertx:vertx-core:3.3.3 io.vertx:vertx-web:3.3.3 io.vertx:vertx-jdbc-client:3.3.3");
+
+        } else if ("svn".equalsIgnoreCase(scm)) {
+            String scmType = manifest.getMainAttributes().getValue(
+                ManifestUtils.attributeName(ExtraManifestKeys.scmType.name()));
+            assertThat(scmType).isNotNull();
+            assertThat(scmType).isEqualToIgnoringCase("SVN");
+            String revision = manifest.getMainAttributes().getValue(
+                ManifestUtils.attributeName(ExtraManifestKeys.scmRevision.name()));
+            assertThat(revision).isNotNull();
+            assertThat(revision).isEqualTo("1381106");
+            assertThat(projectDeps)
+                .isEqualToIgnoringWhitespace("io.vertx:vertx-core:3.3.3 io.vertx:vertx-web:3.3.3");
+        }
+
+    }
+
+
+}

--- a/src/test/java/io/fabric8/vertx/maven/plugin/it/StartStopMojoIT.java
+++ b/src/test/java/io/fabric8/vertx/maven/plugin/it/StartStopMojoIT.java
@@ -178,14 +178,14 @@ public class StartStopMojoIT extends VertxMojoTestBase {
         assertThat(response).isEqualTo("Hello !");
     }
 
-    private void runPackage(Verifier verifier) throws VerificationException, IOException {
-        verifier.setLogFileName("build-package.log");
-        verifier.executeGoal("package");
-
-        assertInLog(verifier, "BUILD SUCCESS");
-        verifier.assertFilePresent("target/vertx-demo-start-0.0.1.BUILD-SNAPSHOT.jar");
-        verifier.resetStreams();
-    }
+//    private void runPackage(Verifier verifier) throws VerificationException, IOException {
+//        verifier.setLogFileName("build-package.log");
+//        verifier.executeGoal("package");
+//
+//        assertInLog(verifier, "BUILD SUCCESS");
+//        verifier.assertFilePresent("target/vertx-demo-start-0.0.1.BUILD-SNAPSHOT.jar");
+//        verifier.resetStreams();
+//    }
 
     public void assertInLog(Verifier verifier, String... snippets) throws IOException {
         File log = new File(verifier.getBasedir(), verifier.getLogFileName());

--- a/src/test/java/io/fabric8/vertx/maven/plugin/it/StartStopMojoIT.java
+++ b/src/test/java/io/fabric8/vertx/maven/plugin/it/StartStopMojoIT.java
@@ -178,15 +178,6 @@ public class StartStopMojoIT extends VertxMojoTestBase {
         assertThat(response).isEqualTo("Hello !");
     }
 
-//    private void runPackage(Verifier verifier) throws VerificationException, IOException {
-//        verifier.setLogFileName("build-package.log");
-//        verifier.executeGoal("package");
-//
-//        assertInLog(verifier, "BUILD SUCCESS");
-//        verifier.assertFilePresent("target/vertx-demo-start-0.0.1.BUILD-SNAPSHOT.jar");
-//        verifier.resetStreams();
-//    }
-
     public void assertInLog(Verifier verifier, String... snippets) throws IOException {
         File log = new File(verifier.getBasedir(), verifier.getLogFileName());
         assertThat(log).isFile();

--- a/src/test/java/io/fabric8/vertx/maven/plugin/it/VertxMojoTestBase.java
+++ b/src/test/java/io/fabric8/vertx/maven/plugin/it/VertxMojoTestBase.java
@@ -4,6 +4,7 @@ package io.fabric8.vertx.maven.plugin.it;
 import com.google.common.collect.ImmutableMap;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOUtils;
+import org.apache.maven.it.VerificationException;
 import org.apache.maven.it.Verifier;
 import org.apache.maven.shared.utils.StringUtils;
 import org.junit.BeforeClass;
@@ -141,5 +142,13 @@ public class VertxMojoTestBase {
         }
         FileUtils.write(input, data, "UTF-8");
         return input;
+    }
+
+    protected void runPackage(Verifier verifier) throws VerificationException, IOException {
+        verifier.setLogFileName("build-package.log");
+        verifier.executeGoal("package");
+
+        verifier.assertFilePresent("target/vertx-demo-start-0.0.1.BUILD-SNAPSHOT.jar");
+        verifier.resetStreams();
     }
 }

--- a/src/test/java/io/fabric8/vertx/maven/plugin/util/GitUtil.java
+++ b/src/test/java/io/fabric8/vertx/maven/plugin/util/GitUtil.java
@@ -1,0 +1,119 @@
+/*
+ *    Copyright (c) 2016 Red Hat, Inc.
+ *
+ *    Red Hat licenses this file to you under the Apache License, version
+ *    2.0 (the "License"); you may not use this file except in compliance
+ *    with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ *    implied.  See the License for the specific language governing
+ *    permissions and limitations under the License.
+ */
+
+package io.fabric8.vertx.maven.plugin.util;
+
+import org.apache.maven.project.MavenProject;
+import org.eclipse.jgit.api.Git;
+import org.eclipse.jgit.api.errors.GitAPIException;
+import org.eclipse.jgit.lib.Repository;
+import org.eclipse.jgit.revwalk.RevCommit;
+import org.eclipse.jgit.storage.file.FileRepositoryBuilder;
+
+import java.io.File;
+import java.io.IOException;
+
+/**
+ * An utility class that is used to manipulate and extract info Git Repository of the project
+ *
+ * @author kameshs
+ */
+public class GitUtil {
+
+    /**
+     * Get the git {@link Repository} if the the project has one
+     *
+     * @param project - the {@link MavenProject} whose Git repo needs to be returned in {@link Repository}
+     * @return Repository  - the Git Repository of the project
+     * @throws IOException - any error that might occur finding the Git folder
+     */
+    public static Repository getGitRepository(MavenProject project) throws IOException {
+
+        MavenProject rootProject = getRootProject(project);
+
+        File baseDir = rootProject.getBasedir();
+
+        if (baseDir == null) {
+            baseDir = project.getBasedir();
+        }
+
+        File gitFolder = findGitFolder(baseDir);
+        if (gitFolder == null) {
+            // No git repository found
+            return null;
+        }
+        FileRepositoryBuilder builder = new FileRepositoryBuilder();
+        Repository repository = builder
+            .readEnvironment()
+            .setGitDir(gitFolder)
+            .build();
+        return repository;
+    }
+
+    /**
+     * Retrieve the git commitId hash
+     *
+     * @param repository - the Git repository from where the latest commit will be retrieved
+     * @return String of Git commit hash
+     * @throws GitAPIException - any Git exception that might occur while getting commitId
+     */
+    public static String getGitCommitId(Repository repository) throws GitAPIException {
+        try {
+            if (repository != null) {
+                Iterable<RevCommit> logs = new Git(repository).log().call();
+                for (RevCommit rev : logs) {
+                    return rev.getName();
+                }
+            }
+        } finally {
+
+        }
+        return null;
+    }
+
+    /**
+     * utility to find &quot;.git&quot; folder of the project
+     *
+     * @param basedir - the base dir as {@link File} where the git folder existence to be checked
+     * @return - the {@link File} reference of the &quot;.git&quot; folder of the project
+     */
+    public static File findGitFolder(File basedir) {
+        File gitDir = new File(basedir, ".git");
+        if (gitDir.exists() && gitDir.isDirectory()) {
+            return gitDir;
+        } else {
+            File parent = basedir.getParentFile();
+            return parent != null ? findGitFolder(parent) : null;
+        }
+    }
+
+    /**
+     * utility to find the root project
+     *
+     * @param project - the project whose root {@link MavenProject} need to be determined
+     * @return root MavenProject of the project
+     */
+    public static MavenProject getRootProject(MavenProject project) {
+        while (project != null) {
+            MavenProject parent = project.getParent();
+            if (parent == null) {
+                break;
+            }
+            project = parent;
+        }
+        return project;
+    }
+}

--- a/src/test/resources/projects/manifest-git-it/pom.xml
+++ b/src/test/resources/projects/manifest-git-it/pom.xml
@@ -1,0 +1,92 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~
+  ~   Copyright (c) 2016 Red Hat, Inc.
+  ~
+  ~   Red Hat licenses this file to you under the Apache License, version
+  ~   2.0 (the "License"); you may not use this file except in compliance
+  ~   with the License.  You may obtain a copy of the License at
+  ~
+  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~   Unless required by applicable law or agreed to in writing, software
+  ~   distributed under the License is distributed on an "AS IS" BASIS,
+  ~   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+  ~   implied.  See the License for the specific language governing
+  ~   permissions and limitations under the License.
+  -->
+
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/POM/4.0.0"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>org.workspace7.maven.plugins.vertx.it</groupId>
+    <artifactId>vertx-demo-start</artifactId>
+    <version>0.0.1.BUILD-SNAPSHOT</version>
+    <scm>
+        <connection>scm:git:https://github.com/fabric8io/vertx-maven-plugin.git</connection>
+        <developerConnection>scm:git:ssh://git@/github.com/fabric8io/vertx-maven-plugin.git</developerConnection>
+        <url>https://github.com/fabric8io/vertx-maven-plugin</url>
+        <tag>HEAD</tag>
+    </scm>
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <vertx.version>3.3.3</vertx.version>
+    </properties>
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <source>1.8</source>
+                    <target>1.8</target>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>@project.groupId@</groupId>
+                <artifactId>@project.artifactId@</artifactId>
+                <version>@project.version@</version>
+                <executions>
+                    <execution>
+                        <id>vmp</id>
+                        <goals>
+                            <goal>initialize</goal>
+                            <goal>package</goal>
+                        </goals>
+                    </execution>
+                </executions>
+
+                <configuration>
+                    <verticle>demo.SimpleVerticle</verticle>
+                </configuration>
+
+            </plugin>
+        </plugins>
+    </build>
+    <dependencies>
+        <dependency>
+            <groupId>io.vertx</groupId>
+            <artifactId>vertx-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.vertx</groupId>
+            <artifactId>vertx-web</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.vertx</groupId>
+            <artifactId>vertx-jdbc-client</artifactId>
+        </dependency>
+    </dependencies>
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>io.vertx</groupId>
+                <artifactId>vertx-dependencies</artifactId>
+                <version>${vertx.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+</project>

--- a/src/test/resources/projects/manifest-git-it/src/main/java/demo/SimpleVerticle.java
+++ b/src/test/resources/projects/manifest-git-it/src/main/java/demo/SimpleVerticle.java
@@ -1,0 +1,30 @@
+/*
+ *
+ *   Copyright (c) 2016 Red Hat, Inc.
+ *
+ *   Red Hat licenses this file to you under the Apache License, version
+ *   2.0 (the "License"); you may not use this file except in compliance
+ *   with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ *   implied.  See the License for the specific language governing
+ *   permissions and limitations under the License.
+ */
+
+package demo;
+
+import io.vertx.core.AbstractVerticle;
+import io.vertx.core.Future;
+
+public class SimpleVerticle extends AbstractVerticle {
+    @Override
+    public void start() throws Exception {
+        vertx.createHttpServer()
+                .requestHandler(req -> req.response().end("aloha " + System.getProperty("vertx.debug")))
+                .listen(8080);
+    }
+}

--- a/src/test/resources/projects/manifest-svn-it/pom.xml
+++ b/src/test/resources/projects/manifest-svn-it/pom.xml
@@ -1,0 +1,86 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright (c) 2016 Red Hat, Inc.
+  ~
+  ~ Red Hat licenses this file to you under the Apache License, version
+  ~ 2.0 (the "License"); you may not use this file except in compliance
+  ~ with the License.  You may obtain a copy of the License at
+  ~
+  ~   http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+  ~ implied.  See the License for the specific language governing
+  ~ permissions and limitations under the License.
+  -->
+
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/POM/4.0.0"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>org.workspace7.maven.plugins.vertx.it</groupId>
+    <artifactId>vertx-demo-start</artifactId>
+    <version>0.0.1.BUILD-SNAPSHOT</version>
+    <scm>
+        <connection>scm:svn:http://svn.apache.org/repos/asf/maven/scm/trunk/maven-scm-client</connection>
+        <url>http://svn.apache.org/repos/asf/maven/scm/trunk/maven-scm-client/</url>
+        <tag>trunk</tag>
+    </scm>
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <vertx.version>3.3.3</vertx.version>
+    </properties>
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <source>1.8</source>
+                    <target>1.8</target>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>@project.groupId@</groupId>
+                <artifactId>@project.artifactId@</artifactId>
+                <version>@project.version@</version>
+                <executions>
+                    <execution>
+                        <id>vmp</id>
+                        <goals>
+                            <goal>initialize</goal>
+                            <goal>package</goal>
+                        </goals>
+                    </execution>
+                </executions>
+
+                <configuration>
+                    <verticle>demo.SimpleVerticle</verticle>
+                </configuration>
+
+            </plugin>
+        </plugins>
+    </build>
+    <dependencies>
+        <dependency>
+            <groupId>io.vertx</groupId>
+            <artifactId>vertx-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.vertx</groupId>
+            <artifactId>vertx-web</artifactId>
+        </dependency>
+    </dependencies>
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>io.vertx</groupId>
+                <artifactId>vertx-dependencies</artifactId>
+                <version>${vertx.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+</project>

--- a/src/test/resources/projects/manifest-svn-it/src/main/java/demo/SimpleVerticle.java
+++ b/src/test/resources/projects/manifest-svn-it/src/main/java/demo/SimpleVerticle.java
@@ -1,0 +1,30 @@
+/*
+ *
+ *   Copyright (c) 2016 Red Hat, Inc.
+ *
+ *   Red Hat licenses this file to you under the Apache License, version
+ *   2.0 (the "License"); you may not use this file except in compliance
+ *   with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ *   implied.  See the License for the specific language governing
+ *   permissions and limitations under the License.
+ */
+
+package demo;
+
+import io.vertx.core.AbstractVerticle;
+import io.vertx.core.Future;
+
+public class SimpleVerticle extends AbstractVerticle {
+    @Override
+    public void start() throws Exception {
+        vertx.createHttpServer()
+                .requestHandler(req -> req.response().end("aloha " + System.getProperty("vertx.debug")))
+                .listen(8080);
+    }
+}

--- a/src/test/resources/unit/jar-packaging/pom-extramf-classifier-jar.xml
+++ b/src/test/resources/unit/jar-packaging/pom-extramf-classifier-jar.xml
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~
+  ~   Copyright (c) 2016 Red Hat, Inc.
+  ~
+  ~   Red Hat licenses this file to you under the Apache License, version
+  ~   2.0 (the "License"); you may not use this file except in compliance
+  ~   with the License.  You may obtain a copy of the License at
+  ~
+  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~   Unless required by applicable law or agreed to in writing, software
+  ~   distributed under the License is distributed on an "AS IS" BASIS,
+  ~   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+  ~   implied.  See the License for the specific language governing
+  ~   permissions and limitations under the License.
+  -->
+
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/POM/4.0.0"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>org.vertx.demo</groupId>
+    <artifactId>vertx-demo</artifactId>
+    <version>1.0.0-SNAPSHOT</version>
+    <packaging>jar</packaging>
+    <build/>
+    <dependencies>
+        <dependency>
+            <groupId>com.example</groupId>
+            <artifactId>example</artifactId>
+            <classifier>vertx</classifier>
+            <version>3.3.3</version>
+        </dependency>
+        <dependency>
+            <groupId>io.vertx</groupId>
+            <artifactId>vertx-unit</artifactId>
+            <version>3.3.3</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>4.12</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/src/test/resources/unit/jar-packaging/pom-extramf-jar.xml
+++ b/src/test/resources/unit/jar-packaging/pom-extramf-jar.xml
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~
+  ~   Copyright (c) 2016 Red Hat, Inc.
+  ~
+  ~   Red Hat licenses this file to you under the Apache License, version
+  ~   2.0 (the "License"); you may not use this file except in compliance
+  ~   with the License.  You may obtain a copy of the License at
+  ~
+  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~   Unless required by applicable law or agreed to in writing, software
+  ~   distributed under the License is distributed on an "AS IS" BASIS,
+  ~   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+  ~   implied.  See the License for the specific language governing
+  ~   permissions and limitations under the License.
+  -->
+
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/POM/4.0.0"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>org.vertx.demo</groupId>
+    <artifactId>vertx-demo</artifactId>
+    <version>1.0.0-SNAPSHOT</version>
+    <packaging>jar</packaging>
+    <build/>
+    <dependencies>
+        <dependency>
+            <groupId>io.vertx</groupId>
+            <artifactId>vertx-core</artifactId>
+            <version>3.3.3</version>
+        </dependency>
+        <dependency>
+            <groupId>io.vertx</groupId>
+            <artifactId>vertx-unit</artifactId>
+            <version>3.3.3</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>4.12</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/src/test/resources/unit/jar-packaging/pom-extramf-scm-jar.xml
+++ b/src/test/resources/unit/jar-packaging/pom-extramf-scm-jar.xml
@@ -1,0 +1,55 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~
+  ~   Copyright (c) 2016 Red Hat, Inc.
+  ~
+  ~   Red Hat licenses this file to you under the Apache License, version
+  ~   2.0 (the "License"); you may not use this file except in compliance
+  ~   with the License.  You may obtain a copy of the License at
+  ~
+  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~   Unless required by applicable law or agreed to in writing, software
+  ~   distributed under the License is distributed on an "AS IS" BASIS,
+  ~   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+  ~   implied.  See the License for the specific language governing
+  ~   permissions and limitations under the License.
+  -->
+
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/POM/4.0.0"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>org.vertx.demo</groupId>
+    <artifactId>vertx-demo</artifactId>
+    <version>1.0.0-SNAPSHOT</version>
+    <packaging>jar</packaging>
+
+    <scm>
+        <connection>scm:git:https://github.com/fabric8io/vertx-maven-plugin.git</connection>
+        <developerConnection>scm:git:ssh://git@/github.com/fabric8io/vertx-maven-plugin.git</developerConnection>
+        <url>https://github.com/fabric8io/vertx-maven-plugin</url>
+        <tag>HEAD</tag>
+    </scm>
+
+    <build/>
+    <dependencies>
+        <dependency>
+            <groupId>com.example</groupId>
+            <artifactId>example</artifactId>
+            <classifier>vertx</classifier>
+            <version>3.3.3</version>
+        </dependency>
+        <dependency>
+            <groupId>io.vertx</groupId>
+            <artifactId>vertx-unit</artifactId>
+            <version>3.3.3</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>4.12</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+</project>


### PR DESCRIPTION

Resolving Issue #72 . This implementation will add SCM details to the `MANIFEST.MF`, sample `MANIFEST.MF` for a Git repo and SVN repo is shown below:

Git
===
```
Manifest-Version: 1.0
Main-Verticle: demo.SimpleVerticle
Project-Name: vertx-demo-start
Project-Dependencies: io.vertx:vertx-core:3.3.3 io.vertx:vertx-web:3.3
 .3 io.vertx:vertx-jdbc-client:3.3.3
Author: Kamesh Sampath <kamesh.sampath@hotmail.com>
Project-Version: 0.0.1.BUILD-SNAPSHOT
Scm-Type: git
Scm-Url: https://github.com/fabric8io/vertx-maven-plugin
Main-Class: io.vertx.core.Launcher
Scm-Revision: 0a43e6b91545bf366b9c4aaea57b9e9e23d1afec
Scm-Tag: HEAD
Project-Group: org.workspace7.maven.plugins.vertx.it
Timestamp: 20170124 17:42:26 IST
```

SVN
===
```
Manifest-Version: 1.0
Main-Verticle: demo.SimpleVerticle
Project-Name: vertx-demo-start
Project-Dependencies: io.vertx:vertx-core:3.3.3 io.vertx:vertx-web:3.3
 .3
Author: olamy
Project-Version: 0.0.1.BUILD-SNAPSHOT
Scm-Type: svn
Scm-Url: http://svn.apache.org/repos/asf/maven/scm/trunk/maven-scm-cli
 ent/
Main-Class: io.vertx.core.Launcher
Scm-Revision: 1381106
Scm-Tag: trunk
Project-Group: org.workspace7.maven.plugins.vertx.it
Timestamp: 20120905 15:06:25 IST
```
