### PR TITLE
Add custom dependencies to the setup Mojo

### DIFF
--- a/src/main/asciidoc/inc/_vertx-setup.adoc
+++ b/src/main/asciidoc/inc/_vertx-setup.adoc
@@ -39,3 +39,13 @@ mvn io.fabric8:vertx-maven-plugin:{version}:setup \
 
 The `verticle` parameter creates a new verticle class file.
 The `dependencies` parameters specifies the Vert.x dependencies you need.
+
+Dependencies are selected from a list of know dependencies matching the one listed on http://vertx.io/docs. In
+addition, you can configure dependencies using the following syntax: `groupId:artifactId:version:classifier` such as in:
+
+----
+io.vertx:vertxcodetrans => Inherit version from BOM
+commons-io:commons-io:2.5 => Regular dependency
+io.vertx:vertx-template-engines:3.4.0-SNAPSHOT:shaded => Dependency with classifier
+----
+

--- a/src/test/java/io/fabric8/vertx/maven/plugin/it/SetupIT.java
+++ b/src/test/java/io/fabric8/vertx/maven/plugin/it/SetupIT.java
@@ -92,6 +92,24 @@ public class SetupIT extends VertxMojoTestBase {
     }
 
     @Test
+    public void testProjectGenerationFromScratchWithCustomDependencies() throws VerificationException, IOException {
+        testDir = initEmptyProject("projects/project-generation-with-verticle-and-custom-deps");
+        assertThat(testDir).isDirectory();
+        initVerifier(testDir);
+        setup(verifier, "-DprojectGroupId=org.acme", "-DprojectArtifactId=acme",
+            "-Dverticle=org.acme.MyVerticle.java", "-Ddependencies=io.vertx:codetrans,commons-io:commons-io:2.5,io" +
+                ".vertx:vertx-template-engines:3.4.0-SNAPSHOT:shaded");
+        assertThat(new File(testDir, "pom.xml")).isFile();
+        assertThat(new File(testDir, "src/main/java")).isDirectory();
+        assertThat(new File(testDir, "src/main/java/org/acme/MyVerticle.java")).isFile();
+        assertThat(FileUtils.readFileToString(new File(testDir, "pom.xml"), "UTF-8"))
+            .contains("<artifactId>codetrans</artifactId>")
+            .contains("<artifactId>commons-io</artifactId>", "<version>2.5</version>", "<groupId>commons-io</groupId>")
+            .contains("<artifactId>vertx-template-engines</artifactId>", "<version>3.4.0-SNAPSHOT</version>",
+                "<classifier>shaded</classifier>");;
+    }
+
+    @Test
     public void testProjectGenerationFromEmptyPomWithDependencies() throws VerificationException, IOException {
         testDir = initProject("projects/simple-pom-it",
             "projects/project-generation-from-empty-pom-with-dependencies");


### PR DESCRIPTION
Add support for custom dependency formats in `-Ddependencies`

```
io.vertx:vertxcodetrans => Inherit version from BOM
commons-io:commons-io:2.5 => Regular dependency
io.vertx:vertx-template-engines:3.4.0-SNAPSHOT:shaded => Dependency with classifier
```