### PR TITLE
SetupMojo UT fix 

### DIFF
--- a/src/test/java/io/fabric8/vertx/maven/plugin/SetupMojoTest.java
+++ b/src/test/java/io/fabric8/vertx/maven/plugin/SetupMojoTest.java
@@ -313,7 +313,8 @@ public class SetupMojoTest {
         assertEquals(project.getArtifactId(), "vertx-example");
         assertEquals(project.getVersion(), "1.0-SNAPSHOT");
         assertEquals(projectProps.getProperty("vertx.version"), vertxVersion);
-        assertEquals(projectProps.getProperty("fabric8-vertx-maven-plugin.version"), "1.0-SNAPSHOT");
+        assertThat(projectProps.getProperty("fabric8-vertx-maven-plugin.version"))
+            .containsPattern("^(\\d?\\.?\\d?)(\\-?SNAPSHOT?|\\.?\\d?)$");
         assertEquals(projectProps.getProperty("vertx.verticle"), "com.example.vertx.MainVerticle");
         DependencyManagement dependencyManagement = project.getDependencyManagement();
         assertThat(dependencyManagement).isNotNull();


### PR DESCRIPTION
The SetupMojoTest when validating the v-m-p version was assuming the version to be `1.0-SNAPSHOT` but during release this check will fail as the versions will be like `n.n.n`. Fixed the UT to regex validate the v-m-p version