### PR TITLE
Fixes Maven coordinates resolution

### DIFF
--- a/src/main/java/io/fabric8/vertx/maven/plugin/mojos/AbstractVertxMojo.java
+++ b/src/main/java/io/fabric8/vertx/maven/plugin/mojos/AbstractVertxMojo.java
@@ -260,7 +260,7 @@ public abstract class AbstractVertxMojo extends AbstractMojo implements Contextu
 
     /**
      * this method helps in resolving the {@link Artifact} as maven coordinates
-     * coordinates ::= group:artifact:version:[packaging]:[classifier]
+     * coordinates ::= group:artifact[:packaging[:classifier]]:version
      *
      * @param artifact - the artifact which need to be represented as maven coordinate
      * @return string representing the maven coordinate
@@ -273,15 +273,14 @@ public abstract class AbstractVertxMojo extends AbstractMojo implements Contextu
         StringBuilder artifactCords = new StringBuilder().
             append(artifact.getGroupId())
             .append(":")
-            .append(artifact.getArtifactId())
-            .append(":")
-            .append(artifact.getVersion());
-        if (!"jar".equals(artifact.getType())) {
+            .append(artifact.getArtifactId());
+        if (!"jar".equals(artifact.getType()) || artifact.hasClassifier()) {
             artifactCords.append(":").append(artifact.getType());
         }
         if (artifact.hasClassifier()) {
             artifactCords.append(":").append(artifact.getClassifier());
         }
+        artifactCords.append(":").append(artifact.getVersion());
         return artifactCords.toString();
     }
 

--- a/src/test/java/io/fabric8/vertx/maven/plugin/AbstractVertxMojoResolveArtifactTest.java
+++ b/src/test/java/io/fabric8/vertx/maven/plugin/AbstractVertxMojoResolveArtifactTest.java
@@ -1,0 +1,79 @@
+package io.fabric8.vertx.maven.plugin;
+
+import java.util.Objects;
+import java.util.ServiceLoader;
+import java.util.stream.StreamSupport;
+
+import io.fabric8.vertx.maven.plugin.mojos.AbstractVertxMojo;
+import org.apache.maven.artifact.Artifact;
+import org.apache.maven.artifact.DefaultArtifact;
+import org.apache.maven.artifact.handler.DefaultArtifactHandler;
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugin.MojoFailureException;
+import org.apache.maven.project.MavenProject;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class AbstractVertxMojoResolveArtifactTest {
+
+
+    private TestMojo mojo;
+    private MavenProject project;
+
+    @Before
+    public void setup() throws Exception {
+        mojo = new TestMojo();
+    }
+
+    @Test
+    public void resolveCoordinates() {
+        checkArtifact(mavenArtifact("com.company", "some-artifact", "0.4.1-SNAPSHOT"));
+        checkArtifact(mavenArtifact("com.company", "some-artifact", "0.4.1-SNAPSHOT", "war", null));
+        checkArtifact(mavenArtifact("com.company", "some-artifact", "0.4.1-SNAPSHOT", "jar", "sources"));
+    }
+
+
+    private void checkArtifact(Artifact artifact) {
+        checkCoordsAgainstSourceArtifact(artifact, mojo.asMavenCoordinates(artifact));
+    }
+
+    private void checkCoordsAgainstSourceArtifact(Artifact mavenArtifact, String coords) {
+        org.eclipse.aether.artifact.DefaultArtifact artifact = new org.eclipse.aether.artifact.DefaultArtifact(coords);
+        assertThat(artifact).extracting(
+            org.eclipse.aether.artifact.DefaultArtifact::getGroupId,
+            org.eclipse.aether.artifact.DefaultArtifact::getArtifactId,
+            org.eclipse.aether.artifact.DefaultArtifact::getVersion,
+            org.eclipse.aether.artifact.DefaultArtifact::getExtension,
+            org.eclipse.aether.artifact.DefaultArtifact::getClassifier
+        ).containsExactly(
+            mavenArtifact.getGroupId(), mavenArtifact.getArtifactId(), mavenArtifact.getVersion(),
+            mavenArtifact.getType(), Objects.toString(mavenArtifact.getClassifier(), "")
+        );
+    }
+
+    private static Artifact mavenArtifact(
+        String groupId, String artifactId, String version) {
+        return mavenArtifact(groupId, artifactId, version, "jar", null);
+    }
+    private static DefaultArtifact mavenArtifact(
+        String groupId, String artifactId, String version, String type, String classifier) {
+        return new DefaultArtifact(
+            groupId, artifactId, version, "compile", type, classifier, new DefaultArtifactHandler()
+        );
+    }
+
+    static class TestMojo extends AbstractVertxMojo {
+
+        @Override
+        public void execute() throws MojoExecutionException, MojoFailureException {
+
+        }
+
+        @Override
+        protected String asMavenCoordinates(Artifact artifact) {
+            return super.asMavenCoordinates(artifact);
+        }
+    }
+}


### PR DESCRIPTION
Maven coordinates was resolved as group:artifact:version:[packaging]:[classifier]
instead of group:artifact[packaging[:classifier]]:version

Fixes #140 